### PR TITLE
Generic changes and tests to keep things working

### DIFF
--- a/lib/Gentoo/Ebuild/ParseVariables.pm
+++ b/lib/Gentoo/Ebuild/ParseVariables.pm
@@ -11,13 +11,16 @@ BEGIN {
 use Sub::Exporter -setup => { exports => [qw( gentoo_ebuild_var )] };
 use Shell::EnvImporter;
 use File::ShareDir;
-#use Data::Dumper;
+use File::Temp qw( tempfile tempdir );
+use File::Basename qw( basename );
 
 sub gentoo_ebuild_var {
 
 	my ( $ebuild, $ebuild_vars, $portdir ) = @_;
 	$ebuild_vars ||= _ebuild_vars();
 	$portdir     ||= "/usr/portage";
+
+	my $td = tempdir();
 
 	my $fixed_eclasses = File::ShareDir::module_dir('Gentoo::Ebuild::ParseVariables');
 	my $ebuildsh       = File::ShareDir::module_file('Gentoo::Ebuild::ParseVariables','ebuild.sh');
@@ -30,35 +33,48 @@ sub gentoo_ebuild_var {
 	(my $pv       = $pvr )=~ s/-r[0-9]+$//;
 	my $pr = ( $pvr =~ m{.*-(r[0-9]+)$} )? $1 : "r0";
 
-	my $command;
-	$command.="unset $_; " for ( @{$ebuild_vars} );
-	$command.="export ";
-	$command.="EBUILD=$ebuild ";
-	$command.="ECLASSDIR=$portdir/eclass ";
-	$command.="PORTDIR_OVERLAY='$repo $fixed_eclasses' ";
-	$command.="CATEGORY=$category ";
-	$command.="PN=$pn ";
-	$command.="PV=$pv ";
-	$command.="PVR=$pvr ";
-	$command.="PF=$pn-$pvr ";
-	$command.="PR=$pr ";
-	$command.="P=$pn-$pv ";
-	$command.="; ";
-	$command.="source $ebuildsh ";
+	my $repo_name = basename $repo;
+	if ( -e "$repo/profiles/repo_name" ) {
+		$repo_name = do {
+			open my $fh, '<:raw', "$repo/profiles/repo_name" or die "Cant open repo_name $!";
+			local $/ = undef;
+			<$fh>;
+		};
+	}
+	my ( $fh, $filename ) = tempfile();
+	print {$fh} "unset $_;\n" for ( @{$ebuild_vars} );
+	print {$fh} "export CATEGORY=$category\n";
+	print {$fh} "export EBUILD=$ebuild\n";
+	print {$fh} "export EBUILD_MASTER_PID=$$\n";
+	print {$fh} "export EBUILD_PHASE=depend\n";
+	print {$fh} "export ECLASSDIR=$portdir/eclass\n";
+	print {$fh} "export P=$pn-$pv\n";
+	print {$fh} "export PF=$pn-$pvr\n";
+	print {$fh} "export PN=$pn\n";
+	print {$fh} "export PORTAGE_BIN_PATH='$fixed_eclasses'\n";
+	print {$fh} "export PORTAGE_ECLASS_LOCATIONS='$fixed_eclasses $repo'\n";
+	print {$fh} "export PORTAGE_PIPE_FD=2\n";
+	print {$fh} "export PORTAGE_REPO_NAME=$repo_name\n";
+	print {$fh} "export PORTAGE_TMPDIR='$td'\n";
+	print {$fh} "export PORTDIR_OVERLAY='$repo $fixed_eclasses'\n";
+	print {$fh} "export PR=$pr\n";
+	print {$fh} "export PV=$pv\n";
+	print {$fh} "export PVR=$pvr\n";
+	print {$fh} "source $ebuildsh\n";
+	close $fh;
 
 	my $sourcer  = Shell::EnvImporter->new(
 		shell       => 'bash',
-		command     => $command,
+		command     => "source $filename",
 		debuglevel  => 0,
 		auto_run    => 0,
 		auto_import => 0,
 	);
-
+	#
 	$sourcer->shellobj->envcmd('set');
 	$sourcer->run;
 	$sourcer->env_import($ebuild_vars);
-
-	my $retval= {};
+	my $retval = {};
 	for my $var ( @{$ebuild_vars} ) {
 		$retval->{$var} = _sanitize($ENV{$var}) if defined $ENV{$var};
 	}

--- a/share/bashrc-functions.sh
+++ b/share/bashrc-functions.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+register_die_hook() {
+	local x
+	for x in $* ; do
+		has $x $EBUILD_DEATH_HOOKS || \
+			export EBUILD_DEATH_HOOKS="$EBUILD_DEATH_HOOKS $x"
+	done
+}
+
+register_success_hook() {
+	local x
+	for x in $* ; do
+		has $x $EBUILD_SUCCESS_HOOKS || \
+			export EBUILD_SUCCESS_HOOKS="$EBUILD_SUCCESS_HOOKS $x"
+	done
+}
+
+__strip_duplicate_slashes() {
+	if [[ -n $1 ]] ; then
+		local removed=$1
+		while [[ ${removed} == *//* ]] ; do
+			removed=${removed//\/\///}
+		done
+		echo "${removed}"
+	fi
+}
+
+KV_major() {
+	[[ -z $1 ]] && return 1
+
+	local KV=$@
+	echo "${KV%%.*}"
+}
+
+KV_minor() {
+	[[ -z $1 ]] && return 1
+
+	local KV=$@
+	KV=${KV#*.}
+	echo "${KV%%.*}"
+}
+
+KV_micro() {
+	[[ -z $1 ]] && return 1
+
+	local KV=$@
+	KV=${KV#*.*.}
+	echo "${KV%%[^[:digit:]]*}"
+}
+
+KV_to_int() {
+	[[ -z $1 ]] && return 1
+
+	local KV_MAJOR=$(KV_major "$1")
+	local KV_MINOR=$(KV_minor "$1")
+	local KV_MICRO=$(KV_micro "$1")
+	local KV_int=$(( KV_MAJOR * 65536 + KV_MINOR * 256 + KV_MICRO ))
+
+	# We make version 2.2.0 the minimum version we will handle as
+	# a sanity check ... if its less, we fail ...
+	if [[ ${KV_int} -ge 131584 ]] ; then
+		echo "${KV_int}"
+		return 0
+	fi
+
+	return 1
+}
+
+_RC_GET_KV_CACHE=""
+get_KV() {
+	[[ -z ${_RC_GET_KV_CACHE} ]] \
+		&& _RC_GET_KV_CACHE=$(uname -r)
+
+	echo $(KV_to_int "${_RC_GET_KV_CACHE}")
+
+	return $?
+}

--- a/share/eapi.sh
+++ b/share/eapi.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# Copyright 2012 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+# PHASES
+
+___eapi_has_pkg_pretend() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3)$ ]]
+}
+
+___eapi_has_src_prepare() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1)$ ]]
+}
+
+___eapi_has_src_configure() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1)$ ]]
+}
+
+___eapi_default_src_test_disables_parallel_jobs() {
+	[[ ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi)$ ]]
+}
+
+___eapi_has_S_WORKDIR_fallback() {
+	[[ ${1-${EAPI-0}} =~ ^(0|1|2|3)$ ]]
+}
+
+# VARIABLES
+
+___eapi_has_prefix_variables() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2)$ || " ${FEATURES} " == *" force-prefix "* ]]
+}
+
+___eapi_has_HDEPEND() {
+	[[ ${1-${EAPI-0}} =~ ^(5-hdepend)$ ]]
+}
+
+___eapi_has_RDEPEND_DEPEND_fallback() {
+	[[ ${1-${EAPI-0}} =~ ^(0|1|2|3)$ ]]
+}
+
+# HELPERS PRESENCE
+
+___eapi_has_dohard() {
+	[[ ${1-${EAPI-0}} =~ ^(0|1|2|3)$ ]]
+}
+
+___eapi_has_dosed() {
+	[[ ${1-${EAPI-0}} =~ ^(0|1|2|3)$ ]]
+}
+
+___eapi_has_einstall() {
+	[[ ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress)$ ]]
+}
+
+___eapi_has_dohtml_deprecated() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress)$ ]]
+}
+
+___eapi_has_docompress() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3)$ ]]
+}
+
+___eapi_has_nonfatal() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3)$ ]]
+}
+
+___eapi_has_doheader() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi)$ ]]
+}
+
+___eapi_has_usex() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi)$ ]]
+}
+
+___eapi_has_get_libdir() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress)$ ]]
+}
+
+___eapi_has_einstalldocs() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress)$ ]]
+}
+
+___eapi_has_eapply() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress)$ ]]
+}
+
+___eapi_has_eapply_user() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress)$ ]]
+}
+
+___eapi_has_in_iuse() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress)$ ]]
+}
+
+___eapi_has_master_repositories() {
+	[[ ${1-${EAPI-0}} =~ ^(5-progress)$ ]]
+}
+
+___eapi_has_repository_path() {
+	[[ ${1-${EAPI-0}} =~ ^(5-progress)$ ]]
+}
+
+___eapi_has_available_eclasses() {
+	[[ ${1-${EAPI-0}} =~ ^(5-progress)$ ]]
+}
+
+___eapi_has_eclass_path() {
+	[[ ${1-${EAPI-0}} =~ ^(5-progress)$ ]]
+}
+
+___eapi_has_license_path() {
+	[[ ${1-${EAPI-0}} =~ ^(5-progress)$ ]]
+}
+
+___eapi_has_package_manager_build_user() {
+	[[ ${1-${EAPI-0}} =~ ^(5-progress)$ ]]
+}
+
+___eapi_has_package_manager_build_group() {
+	[[ ${1-${EAPI-0}} =~ ^(5-progress)$ ]]
+}
+
+# HELPERS BEHAVIOR
+
+___eapi_best_version_and_has_version_support_--host-root() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi)$ ]]
+}
+
+___eapi_unpack_supports_xz() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2)$ ]]
+}
+
+___eapi_unpack_supports_txz() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress)$ ]]
+}
+
+___eapi_econf_passes_--disable-dependency-tracking() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3)$ ]]
+}
+
+___eapi_econf_passes_--disable-silent-rules() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi)$ ]]
+}
+
+___eapi_econf_passes_--docdir_and_--htmldir() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress)$ ]]
+}
+
+___eapi_use_enable_and_use_with_support_empty_third_argument() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3)$ ]]
+}
+
+___eapi_dodoc_supports_-r() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3)$ ]]
+}
+
+___eapi_doins_and_newins_preserve_symlinks() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3)$ ]]
+}
+
+___eapi_newins_supports_reading_from_standard_input() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi)$ ]]
+}
+
+___eapi_helpers_can_die() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3)$ ]]
+}
+
+___eapi_disallows_helpers_in_global_scope() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-slot-abi|5|5-hdepend)$ ]]
+}
+
+___eapi_unpack_is_case_sensitive() {
+	[[ ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend)$ ]]
+}
+
+___eapi_unpack_supports_absolute_paths() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend)$ ]]
+}
+
+___eapi_die_can_respect_nonfatal() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress)$ ]]
+}
+
+# OTHERS
+
+___eapi_enables_failglob_in_global_scope() {
+	[[ ! ${1-${EAPI-0}} =~ ^(0|1|2|3|4|4-python|4-slot-abi|5|5-hdepend|5-progress)$ ]]
+}
+
+___eapi_enables_globstar() {
+	[[ ${1-${EAPI-0}} =~ ^(4-python|5-progress)$ ]]
+}

--- a/share/ebuild.sh
+++ b/share/ebuild.sh
@@ -1,12 +1,80 @@
 #!/bin/bash
-# Copyright 1999-2011 Gentoo Foundation
+# Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-EBUILD_PHASE=depend
+PORTAGE_BIN_PATH="${PORTAGE_BIN_PATH:-/usr/lib/portage/bin}"
+PORTAGE_PYM_PATH="${PORTAGE_PYM_PATH:-/usr/lib/portage/pym}"
 
-. /usr/lib64/portage/bin/isolated-functions.sh
+# Prevent aliases from causing portage to act inappropriately.
+# Make sure it's before everything so we don't mess aliases that follow.
+unalias -a
 
-qa_source() {
+source "${PORTAGE_BIN_PATH}/isolated-functions.sh" || exit 1
+
+if [[ $EBUILD_PHASE != depend ]] ; then
+	source "${PORTAGE_BIN_PATH}/phase-functions.sh" || die
+	source "${PORTAGE_BIN_PATH}/save-ebuild-env.sh" || die
+	source "${PORTAGE_BIN_PATH}/phase-helpers.sh" || die
+	source "${PORTAGE_BIN_PATH}/bashrc-functions.sh" || die
+else
+	# These dummy functions are for things that are likely to be called
+	# in global scope, even though they are completely useless during
+	# the "depend" phase.
+	for x in diropts docompress exeopts get_KV insopts \
+		KV_major KV_micro KV_minor KV_to_int \
+		libopts register_die_hook register_success_hook \
+		__strip_duplicate_slashes \
+		use_with use_enable ; do
+		eval "${x}() {
+			if ___eapi_disallows_helpers_in_global_scope; then
+				die \"\${FUNCNAME}() calls are not allowed in global scope\"
+			fi
+		}"
+	done
+	# These dummy functions return false in non-strict EAPIs, in order to ensure that
+	# `use multislot` is false for the "depend" phase.
+	funcs="use useq usev"
+	___eapi_has_usex && funcs+=" usex"
+	for x in ${funcs} ; do
+		eval "${x}() {
+			if ___eapi_disallows_helpers_in_global_scope; then
+				die \"\${FUNCNAME}() calls are not allowed in global scope\"
+			else
+				return 1
+			fi
+		}"
+	done
+	# These functions die because calls to them during the "depend" phase
+	# are considered to be severe QA violations.
+	funcs="best_version has_version portageq"
+	___eapi_has_master_repositories && funcs+=" master_repositories"
+	___eapi_has_repository_path && funcs+=" repository_path"
+	___eapi_has_available_eclasses && funcs+=" available_eclasses"
+	___eapi_has_eclass_path && funcs+=" eclass_path"
+	___eapi_has_license_path && funcs+=" license_path"
+	for x in ${funcs} ; do
+		eval "${x}() { die \"\${FUNCNAME}() calls are not allowed in global scope\"; }"
+	done
+	unset funcs x
+fi
+
+# Don't use sandbox's BASH_ENV for new shells because it does
+# 'source /etc/profile' which can interfere with the build
+# environment by modifying our PATH.
+unset BASH_ENV
+
+# This is just a temporary workaround for portage-9999 users since
+# earlier portage versions do not detect a version change in this case
+# (9999 to 9999) and therefore they try execute an incompatible version of
+# ebuild.sh during the upgrade.
+export PORTAGE_BZIP2_COMMAND=${PORTAGE_BZIP2_COMMAND:-bzip2} 
+
+# These two functions wrap sourcing and calling respectively.  At present they
+# perform a qa check to make sure eclasses and ebuilds and profiles don't mess
+# with shell opts (shopts).  Ebuilds/eclasses changing shopts should reset them 
+# when they are done.
+
+__qa_source() {
 	local shopts=$(shopt) OLDIFS="$IFS"
 	local retval
 	source "$@"
@@ -19,145 +87,109 @@ qa_source() {
 	return $retval
 }
 
-# Prevent aliases from causing portage to act inappropriately.
-# Make sure it's before everything so we don't mess aliases that follow.
-unalias -a
+__qa_call() {
+	local shopts=$(shopt) OLDIFS="$IFS"
+	local retval
+	"$@"
+	retval=$?
+	set +e
+	[[ $shopts != $(shopt) ]] &&
+		eqawarn "QA Notice: Global shell options changed and were not restored while calling '$*'"
+	[[ "$IFS" != "$OLDIFS" ]] &&
+		eqawarn "QA Notice: Global IFS changed and was not restored while calling '$*'"
+	return $retval
+}
+
+EBUILD_SH_ARGS="$*"
+
+shift $#
 
 # Unset some variables that break things.
 unset GZIP BZIP BZIP2 CDPATH GREP_OPTIONS GREP_COLOR GLOBIGNORE
 
-source "${PORTAGE_BIN_PATH}/isolated-functions.sh"  &>/dev/null
+[[ $PORTAGE_QUIET != "" ]] && export PORTAGE_QUIET
 
-
-useq() {
-	eqawarn "QA Notice: The 'useq' function is deprecated (replaced by 'use')"
-	use ${1}
+# sandbox support functions; defined prior to profile.bashrc srcing, since the profile might need to add a default exception (/usr/lib64/conftest fex)
+__sb_append_var() {
+	local _v=$1 ; shift
+	local var="SANDBOX_${_v}"
+	[[ -z $1 || -n $2 ]] && die "Usage: add$(LC_ALL=C tr "[:upper:]" "[:lower:]" <<< "${_v}") <colon-delimited list of paths>"
+	export ${var}="${!var:+${!var}:}$1"
 }
+# bash-4 version:
+# local var="SANDBOX_${1^^}"
+# addread() { __sb_append_var ${0#add} "$@" ; }
+addread()    { __sb_append_var READ    "$@" ; }
+addwrite()   { __sb_append_var WRITE   "$@" ; }
+adddeny()    { __sb_append_var DENY    "$@" ; }
+addpredict() { __sb_append_var PREDICT "$@" ; }
 
+addwrite "${PORTAGE_TMPDIR}"
+addread "/:${PORTAGE_TMPDIR}"
+[[ -n ${PORTAGE_GPG_DIR} ]] && addpredict "${PORTAGE_GPG_DIR}"
 
-usev() {
-	if use ${1}; then
-		echo "${1#!}"
-		return 0
-	fi
-	return 1
-}
+# Avoid sandbox violations in temporary directories.
+if [[ -w $T ]] ; then
+	export TEMP=$T
+	export TMP=$T
+	export TMPDIR=$T
+elif [[ $SANDBOX_ON = 1 ]] ; then
+	for x in TEMP TMP TMPDIR ; do
+		[[ -n ${!x} ]] && addwrite "${!x}"
+	done
+	unset x
+fi
 
-use() {
-	local u=$1
-	local found=0
+# the sandbox is disabled by default except when overridden in the relevant stages
+export SANDBOX_ON=0
 
-	# if we got something like '!flag', then invert the return value
-	if [[ ${u:0:1} == "!" ]] ; then
-		u=${u:1}
-		found=1
-	fi
+# Ensure that $PWD is sane whenever possible, to protect against
+# exploitation of insecure search path for python -c in ebuilds.
+# See bug #239560 and bug #469338.
+cd "${PORTAGE_PYM_PATH}" || \
+	die "PORTAGE_PYM_PATH does not exist: '${PORTAGE_PYM_PATH}'"
 
-	if [[ $EBUILD_PHASE = depend ]] ; then
-		# TODO: Add a registration interface for eclasses to register
-		# any number of phase hooks, so that global scope eclass
-		# initialization can by migrated to phase hooks in new EAPIs.
-		# Example: add_phase_hook before pkg_setup $ECLASS_pre_pkg_setup
-		#if [[ -n $EAPI ]] && ! has "$EAPI" 0 1 2 3 ; then
-		#	die "use() called during invalid phase: $EBUILD_PHASE"
-		#fi
-		true
+#if no perms are specified, dirs/files will have decent defaults
+#(not secretive, but not stupid)
+umask 022
 
-	# Make sure we have this USE flag in IUSE
-	elif [[ -n $PORTAGE_IUSE && -n $EBUILD_PHASE ]] ; then
-		[[ $u =~ $PORTAGE_IUSE ]] || \
-			eqawarn "QA Notice: USE Flag '${u}' not" \
-				"in IUSE for ${CATEGORY}/${PF}"
-	fi
+# debug-print() gets called from many places with verbose status information useful
+# for tracking down problems. The output is in $T/eclass-debug.log.
+# You can set ECLASS_DEBUG_OUTPUT to redirect the output somewhere else as well.
+# The special "on" setting echoes the information, mixing it with the rest of the
+# emerge output.
+# You can override the setting by exporting a new one from the console, or you can
+# set a new default in make.*. Here the default is "" or unset.
 
-	if has ${u} ${USE} ; then
-		return ${found}
-	else
-		return $((!found))
-	fi
-}
-
-# Return true if given package is installed. Otherwise return false.
-# Takes single depend-type atoms.
-has_version() {
-	if [ "${EBUILD_PHASE}" == "depend" ]; then
-		die "portageq calls (has_version calls portageq) are not allowed in the global scope"
-	fi
-}
-
-portageq() {
-	if [ "${EBUILD_PHASE}" == "depend" ]; then
-		die "portageq calls are not allowed in the global scope"
-	fi
-}
-
-# Returns the best/most-current match.
-# Takes single depend-type atoms.
-best_version() {
-	if [ "${EBUILD_PHASE}" == "depend" ]; then
-		die "portageq calls (best_version calls portageq) are not allowed in the global scope"
-	fi
-}
-
-use_with() {
-	if [ -z "$1" ]; then
-		echo "!!! use_with() called without a parameter." >&2
-		echo "!!! use_with <USEFLAG> [<flagname> [value]]" >&2
-		return 1
-	fi
-
-	if ! has "${EAPI:-0}" 0 1 2 3 ; then
-		local UW_SUFFIX=${3+=$3}
-	else
-		local UW_SUFFIX=${3:+=$3}
-	fi
-	local UWORD=${2:-$1}
-
-	if use $1; then
-		echo "--with-${UWORD}${UW_SUFFIX}"
-	else
-		echo "--without-${UWORD}"
-	fi
-	return 0
-}
-
-use_enable() {
-	if [ -z "$1" ]; then
-		echo "!!! use_enable() called without a parameter." >&2
-		echo "!!! use_enable <USEFLAG> [<flagname> [value]]" >&2
-		return 1
-	fi
-
-	if ! has "${EAPI:-0}" 0 1 2 3 ; then
-		local UE_SUFFIX=${3+=$3}
-	else
-		local UE_SUFFIX=${3:+=$3}
-	fi
-	local UWORD=${2:-$1}
-
-	if use $1; then
-		echo "--enable-${UWORD}${UE_SUFFIX}"
-	else
-		echo "--disable-${UWORD}"
-	fi
-	return 0
-}
-
-
+# in the future might use e* from /etc/init.d/functions.sh if i feel like it
 debug-print() {
-	true
+	# if $T isn't defined, we're in dep calculation mode and
+	# shouldn't do anything
+	[[ $EBUILD_PHASE = depend || ! -d ${T} || ${#} -eq 0 ]] && return 0
+
+	if [[ ${ECLASS_DEBUG_OUTPUT} == on ]]; then
+		printf 'debug: %s\n' "${@}" >&2
+	elif [[ -n ${ECLASS_DEBUG_OUTPUT} ]]; then
+		printf 'debug: %s\n' "${@}" >> "${ECLASS_DEBUG_OUTPUT}"
+	fi
+
+	if [[ -w $T ]] ; then
+		# default target
+		printf '%s\n' "${@}" >> "${T}/eclass-debug.log"
+		# let the portage user own/write to this file
+		chgrp "${PORTAGE_GRPNAME:-portage}" "${T}/eclass-debug.log"
+		chmod g+w "${T}/eclass-debug.log"
+	fi
 }
+
+# The following 2 functions are debug-print() wrappers
 
 debug-print-function() {
-	#echo "$@" >&2
-	#printf 'debug: %s\n' "${@}" >&2
-	true
+	debug-print "${1}: entering function, parameters: ${*:2}"
 }
+
 debug-print-section() {
-	true
-}
-die() {
-	exit
+	debug-print "now in section ${*}"
 }
 
 # Sources all eclasses in parameters
@@ -175,8 +207,9 @@ inherit() {
 			| fmt -w 75 | while read -r ; do eqawarn "$REPLY" ; done
 	fi
 
+	local repo_location
 	local location
-	local olocation
+	local potential_location
 	local x
 
 	# These variables must be restored before returning.
@@ -188,92 +221,110 @@ inherit() {
 	local B_DEPEND
 	local B_RDEPEND
 	local B_PDEPEND
+	local B_HDEPEND
 	while [ "$1" ]; do
-		location="${ECLASSDIR}/${1}.eclass"
-		olocation=""
+		location=""
+		potential_location=""
 
 		export ECLASS="$1"
 		__export_funcs_var=__export_functions_$ECLASS_DEPTH
 		unset $__export_funcs_var
 
-		# any future resolution code goes here
-		if [ -n "$PORTDIR_OVERLAY" ]; then
-			local overlay
-			for overlay in ${PORTDIR_OVERLAY}; do
-				olocation="${overlay}/eclass/${1}.eclass"
-				if [ -e "$olocation" ]; then
-					location="${olocation}"
-					debug-print "  eclass exists: ${location}"
-				fi
-			done
+		if [[ ${EBUILD_PHASE} != depend && ${EBUILD_PHASE} != nofetch && \
+			${EBUILD_PHASE} != *rm && ${EMERGE_FROM} != "binary" && \
+			-z ${_IN_INSTALL_QA_CHECK} ]]
+		then
+			# This is disabled in the *rm phases because they frequently give
+			# false alarms due to INHERITED in /var/db/pkg being outdated
+			# in comparison the the eclasses from the portage tree. It's
+			# disabled for nofetch, since that can be called by repoman and
+			# that triggers bug #407449 due to repoman not exporting
+			# non-essential variables such as INHERITED.
+			if ! has $ECLASS $INHERITED $__INHERITED_QA_CACHE ; then
+				eqawarn "QA Notice: ECLASS '$ECLASS' inherited illegally in $CATEGORY/$PF $EBUILD_PHASE"
+			fi
 		fi
+
+		for repo_location in "${PORTAGE_ECLASS_LOCATIONS[@]}"; do
+			potential_location="${repo_location}/eclass/${1}.eclass"
+			if [[ -f ${potential_location} ]]; then
+				location="${potential_location}"
+				debug-print "  eclass exists: ${location}"
+				break
+			fi
+		done
 		debug-print "inherit: $1 -> $location"
-		[ ! -e "$location" ] && die "${1}.eclass could not be found by inherit()"
+		[[ -z ${location} ]] && die "${1}.eclass could not be found by inherit()"
 
-		if [ "${location}" == "${olocation}" ] && \
-			! has "${location}" ${EBUILD_OVERLAY_ECLASSES} ; then
-				EBUILD_OVERLAY_ECLASSES="${EBUILD_OVERLAY_ECLASSES} ${location}"
+		# inherits in QA checks can't handle metadata assignments
+		if [[ -z ${_IN_INSTALL_QA_CHECK} ]]; then
+			#We need to back up the values of *DEPEND to B_*DEPEND
+			#(if set).. and then restore them after the inherit call.
+
+			#turn off glob expansion
+			set -f
+
+			# Retain the old data and restore it later.
+			unset B_IUSE B_REQUIRED_USE B_DEPEND B_RDEPEND B_PDEPEND B_HDEPEND
+			[ "${IUSE+set}"       = set ] && B_IUSE="${IUSE}"
+			[ "${REQUIRED_USE+set}" = set ] && B_REQUIRED_USE="${REQUIRED_USE}"
+			[ "${DEPEND+set}"     = set ] && B_DEPEND="${DEPEND}"
+			[ "${RDEPEND+set}"    = set ] && B_RDEPEND="${RDEPEND}"
+			[ "${PDEPEND+set}"    = set ] && B_PDEPEND="${PDEPEND}"
+			[ "${HDEPEND+set}"    = set ] && B_HDEPEND="${HDEPEND}"
+			unset IUSE REQUIRED_USE DEPEND RDEPEND PDEPEND HDEPEND
+			#turn on glob expansion
+			set +f
 		fi
 
-		#We need to back up the value of DEPEND and RDEPEND to B_DEPEND and B_RDEPEND
-		#(if set).. and then restore them after the inherit call.
-
-		#turn off glob expansion
-		set -f
-
-		# Retain the old data and restore it later.
-		unset B_IUSE B_REQUIRED_USE B_DEPEND B_RDEPEND B_PDEPEND
-		[ "${IUSE+set}"       = set ] && B_IUSE="${IUSE}"
-		[ "${REQUIRED_USE+set}" = set ] && B_REQUIRED_USE="${REQUIRED_USE}"
-		[ "${DEPEND+set}"     = set ] && B_DEPEND="${DEPEND}"
-		[ "${RDEPEND+set}"    = set ] && B_RDEPEND="${RDEPEND}"
-		[ "${PDEPEND+set}"    = set ] && B_PDEPEND="${PDEPEND}"
-		unset IUSE REQUIRED_USE DEPEND RDEPEND PDEPEND
-		#turn on glob expansion
-		set +f
-
-		qa_source "$location" || die "died sourcing $location in inherit()"
+		__qa_source "$location" || die "died sourcing $location in inherit()"
 		
-		#turn off glob expansion
-		set -f
+		if [[ -z ${_IN_INSTALL_QA_CHECK} ]]; then
+			#turn off glob expansion
+			set -f
 
-		# If each var has a value, append it to the global variable E_* to
-		# be applied after everything is finished. New incremental behavior.
-		[ "${IUSE+set}"       = set ] && export E_IUSE="${E_IUSE} ${IUSE}"
-		[ "${REQUIRED_USE+set}"       = set ] && export E_REQUIRED_USE="${E_REQUIRED_USE} ${REQUIRED_USE}"
-		[ "${DEPEND+set}"     = set ] && export E_DEPEND="${E_DEPEND} ${DEPEND}"
-		[ "${RDEPEND+set}"    = set ] && export E_RDEPEND="${E_RDEPEND} ${RDEPEND}"
-		[ "${PDEPEND+set}"    = set ] && export E_PDEPEND="${E_PDEPEND} ${PDEPEND}"
+			# If each var has a value, append it to the global variable E_* to
+			# be applied after everything is finished. New incremental behavior.
+			[ "${IUSE+set}"         = set ] && E_IUSE+="${E_IUSE:+ }${IUSE}"
+			[ "${REQUIRED_USE+set}" = set ] && E_REQUIRED_USE+="${E_REQUIRED_USE:+ }${REQUIRED_USE}"
+			[ "${DEPEND+set}"       = set ] && E_DEPEND+="${E_DEPEND:+ }${DEPEND}"
+			[ "${RDEPEND+set}"      = set ] && E_RDEPEND+="${E_RDEPEND:+ }${RDEPEND}"
+			[ "${PDEPEND+set}"      = set ] && E_PDEPEND+="${E_PDEPEND:+ }${PDEPEND}"
+			[ "${HDEPEND+set}"      = set ] && E_HDEPEND+="${E_HDEPEND:+ }${HDEPEND}"
 
-		[ "${B_IUSE+set}"     = set ] && IUSE="${B_IUSE}"
-		[ "${B_IUSE+set}"     = set ] || unset IUSE
-		
-		[ "${B_REQUIRED_USE+set}"     = set ] && REQUIRED_USE="${B_REQUIRED_USE}"
-		[ "${B_REQUIRED_USE+set}"     = set ] || unset REQUIRED_USE
+			[ "${B_IUSE+set}"     = set ] && IUSE="${B_IUSE}"
+			[ "${B_IUSE+set}"     = set ] || unset IUSE
+			
+			[ "${B_REQUIRED_USE+set}"     = set ] && REQUIRED_USE="${B_REQUIRED_USE}"
+			[ "${B_REQUIRED_USE+set}"     = set ] || unset REQUIRED_USE
 
-		[ "${B_DEPEND+set}"   = set ] && DEPEND="${B_DEPEND}"
-		[ "${B_DEPEND+set}"   = set ] || unset DEPEND
+			[ "${B_DEPEND+set}"   = set ] && DEPEND="${B_DEPEND}"
+			[ "${B_DEPEND+set}"   = set ] || unset DEPEND
 
-		[ "${B_RDEPEND+set}"  = set ] && RDEPEND="${B_RDEPEND}"
-		[ "${B_RDEPEND+set}"  = set ] || unset RDEPEND
+			[ "${B_RDEPEND+set}"  = set ] && RDEPEND="${B_RDEPEND}"
+			[ "${B_RDEPEND+set}"  = set ] || unset RDEPEND
 
-		[ "${B_PDEPEND+set}"  = set ] && PDEPEND="${B_PDEPEND}"
-		[ "${B_PDEPEND+set}"  = set ] || unset PDEPEND
+			[ "${B_PDEPEND+set}"  = set ] && PDEPEND="${B_PDEPEND}"
+			[ "${B_PDEPEND+set}"  = set ] || unset PDEPEND
 
-		#turn on glob expansion
-		set +f
+			[ "${B_HDEPEND+set}"  = set ] && HDEPEND="${B_HDEPEND}"
+			[ "${B_HDEPEND+set}"  = set ] || unset HDEPEND
 
-		if [[ -n ${!__export_funcs_var} ]] ; then
-			for x in ${!__export_funcs_var} ; do
-				debug-print "EXPORT_FUNCTIONS: $x -> ${ECLASS}_$x"
-				declare -F "${ECLASS}_$x" >/dev/null || \
-					die "EXPORT_FUNCTIONS: ${ECLASS}_$x is not defined"
-				eval "$x() { ${ECLASS}_$x \"\$@\" ; }" > /dev/null
-			done
+			#turn on glob expansion
+			set +f
+
+			if [[ -n ${!__export_funcs_var} ]] ; then
+				for x in ${!__export_funcs_var} ; do
+					debug-print "EXPORT_FUNCTIONS: $x -> ${ECLASS}_$x"
+					declare -F "${ECLASS}_$x" >/dev/null || \
+						die "EXPORT_FUNCTIONS: ${ECLASS}_$x is not defined"
+					eval "$x() { ${ECLASS}_$x \"\$@\" ; }" > /dev/null
+				done
+			fi
+			unset $__export_funcs_var
+
+			has $1 $INHERITED || export INHERITED="$INHERITED $1"
 		fi
-		unset $__export_funcs_var
-
-		has $1 $INHERITED || export INHERITED="$INHERITED $1"
 
 		shift
 	done
@@ -298,10 +349,236 @@ EXPORT_FUNCTIONS() {
 	eval $__export_funcs_var+=\" $*\"
 }
 
+PORTAGE_BASHRCS_SOURCED=0
+
+# @FUNCTION: __source_all_bashrcs
+# @DESCRIPTION:
+# Source a relevant bashrc files and perform other miscellaneous
+# environment initialization when appropriate.
+#
+# If EAPI is set then define functions provided by the current EAPI:
+#
+#  * default_* aliases for the current EAPI phase functions
+#  * A "default" function which is an alias for the default phase
+#    function for the current phase.
+#
+__source_all_bashrcs() {
+	[[ $PORTAGE_BASHRCS_SOURCED = 1 ]] && return 0
+	PORTAGE_BASHRCS_SOURCED=1
+	local x
+
+	local OCC="${CC}" OCXX="${CXX}"
+
+	if [[ $EBUILD_PHASE != depend ]] ; then
+		# source the existing profile.bashrcs.
+		save_IFS
+		IFS=$'\n'
+		local bashenv_files=($PORTAGE_BASHRC_FILES)
+		restore_IFS
+		for x in "${bashenv_files[@]}" ; do
+			__try_source "${x}"
+		done
+	fi
+
+	# The user's bashrc is the ONLY non-portage bit of code
+	# that can change shopts without a QA violation.
+	__try_source --no-qa "${PORTAGE_BASHRC}"
+
+	if [[ $EBUILD_PHASE != depend ]] ; then
+		__source_env_files --no-qa "${PM_EBUILD_HOOK_DIR}"
+	fi
+
+	[ ! -z "${OCC}" ] && export CC="${OCC}"
+	[ ! -z "${OCXX}" ] && export CXX="${OCXX}"
+}
+
+# @FUNCTION: __source_env_files
+# @USAGE: [--no-qa] <ENV_DIRECTORY>
+# @DESCRIPTION:
+# Source the files relevant to the current package from the given path.
+# If --no-qa is specified, use source instead of __qa_source to source the
+# files.
+__source_env_files() {
+	local argument=()
+	if [[ $1 == --no-qa ]]; then
+		argument=( --no-qa )
+	shift
+	fi
+	for x in "${1}"/${CATEGORY}/{${PN},${PN}:${SLOT%/*},${P},${PF}}; do
+		__try_source "${argument[@]}" "${x}"
+	done
+}
+
+# @FUNCTION: __try_source
+# @USAGE: [--no-qa] <FILE>
+# @DESCRIPTION:
+# If the path given as argument exists, source the file while preserving
+# $-.
+# If --no-qa is specified, source the file with source instead of __qa_source.
+__try_source() {
+	local qa=true
+	if [[ $1 == --no-qa ]]; then
+		qa=false
+		shift
+	fi
+	if [[ -r $1 && -f $1 ]]; then
+		local debug_on=false
+		if [[ "$PORTAGE_DEBUG" == "1" ]] && [[ "${-/x/}" == "$-" ]]; then
+			debug_on=true
+		fi
+		$debug_on && set -x
+		# If $- contains x, then tracing has already been enabled
+		# elsewhere for some reason. We preserve it's state so as
+		# not to interfere.
+		if [[ ${qa} ]]; then
+			source "${1}"
+		else
+			__qa_source "${1}"
+		fi
+		$debug_on && set +x
+	fi
+}
+# === === === === === === === === === === === === === === === === === ===
+# === === === === === functions end, main part begins === === === === ===
+# === === === === === === === === === === === === === === === === === ===
+
+export SANDBOX_ON="1"
+export S=${WORKDIR}/${P}
+
+# Turn of extended glob matching so that g++ doesn't get incorrectly matched.
+shopt -u extglob
+
+if [[ ${EBUILD_PHASE} == depend ]] ; then
+	QA_INTERCEPTORS="awk bash cc egrep equery fgrep g++
+		gawk gcc grep javac java-config nawk perl
+		pkg-config python python-config sed"
+elif [[ ${EBUILD_PHASE} == clean* ]] ; then
+	unset QA_INTERCEPTORS
+else
+	QA_INTERCEPTORS="autoconf automake aclocal libtoolize"
+fi
+# level the QA interceptors if we're in depend
+if [[ -n ${QA_INTERCEPTORS} ]] ; then
+	for BIN in ${QA_INTERCEPTORS}; do
+		BIN_PATH=$(type -Pf ${BIN})
+		if [ "$?" != "0" ]; then
+			BODY="echo \"*** missing command: ${BIN}\" >&2; return 127"
+		else
+			BODY="${BIN_PATH} \"\$@\"; return \$?"
+		fi
+		if [[ ${EBUILD_PHASE} == depend ]] ; then
+			FUNC_SRC="${BIN}() {
+				if [ \$ECLASS_DEPTH -gt 0 ]; then
+					eqawarn \"QA Notice: '${BIN}' called in global scope: eclass \${ECLASS}\"
+				else
+					eqawarn \"QA Notice: '${BIN}' called in global scope: \${CATEGORY}/\${PF}\"
+				fi
+			${BODY}
+			}"
+		elif has ${BIN} autoconf automake aclocal libtoolize ; then
+			FUNC_SRC="${BIN}() {
+				if ! has \${FUNCNAME[1]} eautoreconf eaclocal _elibtoolize \\
+					eautoheader eautoconf eautomake autotools_run_tool \\
+					autotools_check_macro autotools_get_subdirs \\
+					autotools_get_auxdir ; then
+					eqawarn \"QA Notice: '${BIN}' called by \${FUNCNAME[1]}: \${CATEGORY}/\${PF}\"
+					eqawarn \"Use autotools.eclass instead of calling '${BIN}' directly.\"
+				fi
+			${BODY}
+			}"
+		else
+			FUNC_SRC="${BIN}() {
+				eqawarn \"QA Notice: '${BIN}' called by \${FUNCNAME[1]}: \${CATEGORY}/\${PF}\"
+			${BODY}
+			}"
+		fi
+		eval "$FUNC_SRC" || echo "error creating QA interceptor ${BIN}" >&2
+	done
+	unset BIN_PATH BIN BODY FUNC_SRC
+fi
+
+# Subshell/helper die support (must export for the die helper).
+export EBUILD_MASTER_PID=${BASHPID:-$(__bashpid)}
+trap 'exit 1' SIGTERM
+
+if ! has "$EBUILD_PHASE" clean cleanrm depend && \
+	! [[ $EMERGE_FROM = ebuild && $EBUILD_PHASE = setup ]] && \
+	[ -f "${T}"/environment ] ; then
+	# The environment may have been extracted from environment.bz2 or
+	# may have come from another version of ebuild.sh or something.
+	# In any case, preprocess it to prevent any potential interference.
+	# NOTE: export ${FOO}=... requires quoting, unlike normal exports
+	__preprocess_ebuild_env || \
+		die "error processing environment"
+	# Colon separated SANDBOX_* variables need to be cumulative.
+	for x in SANDBOX_DENY SANDBOX_READ SANDBOX_PREDICT SANDBOX_WRITE ; do
+		export PORTAGE_${x}="${!x}"
+	done
+	PORTAGE_SANDBOX_ON=${SANDBOX_ON}
+	export SANDBOX_ON=1
+	source "${T}"/environment || \
+		die "error sourcing environment"
+	# We have to temporarily disable sandbox since the
+	# SANDBOX_{DENY,READ,PREDICT,WRITE} values we've just loaded
+	# may be unusable (triggering in spurious sandbox violations)
+	# until we've merged them with our current values.
+	export SANDBOX_ON=0
+	for x in SANDBOX_DENY SANDBOX_PREDICT SANDBOX_READ SANDBOX_WRITE ; do
+		y="PORTAGE_${x}"
+		if [ -z "${!x}" ] ; then
+			export ${x}="${!y}"
+		elif [ -n "${!y}" ] && [ "${!y}" != "${!x}" ] ; then
+			# filter out dupes
+			export ${x}="$(printf "${!y}:${!x}" | tr ":" "\0" | \
+				sort -z -u | tr "\0" ":")"
+		fi
+		export ${x}="${!x%:}"
+		unset PORTAGE_${x}
+	done
+	unset x y
+	export SANDBOX_ON=${PORTAGE_SANDBOX_ON}
+	unset PORTAGE_SANDBOX_ON
+	[[ -n $EAPI ]] || EAPI=0
+fi
+
+if ___eapi_enables_globstar; then
+	shopt -s globstar
+fi
+
+# Convert quoted paths to array.
+eval "PORTAGE_ECLASS_LOCATIONS=(${PORTAGE_ECLASS_LOCATIONS})"
+
+# Source the ebuild every time for FEATURES=noauto, so that ebuild
+# modifications take effect immediately.
+if ! has "$EBUILD_PHASE" clean cleanrm ; then
+	if [[ $EBUILD_PHASE = setup && $EMERGE_FROM = ebuild ]] || \
+		[[ $EBUILD_PHASE = depend || ! -f $T/environment || \
+		-f $PORTAGE_BUILDDIR/.ebuild_changed || \
+		" ${FEATURES} " == *" noauto "* ]] ; then
+		# The bashrcs get an opportunity here to set aliases that will be expanded
+		# during sourcing of ebuilds and eclasses.
+		__source_all_bashrcs
+
+		# When EBUILD_PHASE != depend, INHERITED comes pre-initialized
+		# from cache. In order to make INHERITED content independent of
+		# EBUILD_PHASE during inherit() calls, we unset INHERITED after
+		# we make a backup copy for QA checks.
+		__INHERITED_QA_CACHE=$INHERITED
+
+		# Catch failed globbing attempts in case ebuild writer forgot to
+		# escape '*' or likes.
+		# Note: this needs to be done before unsetting EAPI.
+		if ___eapi_enables_failglob_in_global_scope; then
+			shopt -s failglob
+		fi
+
+		# *DEPEND and IUSE will be set during the sourcing of the ebuild.
 		# In order to ensure correct interaction between ebuilds and
 		# eclasses, they need to be unset before this process of
 		# interaction begins.
-		unset DEPEND RDEPEND PDEPEND IUSE REQUIRED_USE
+		unset EAPI DEPEND RDEPEND PDEPEND HDEPEND INHERITED IUSE REQUIRED_USE \
+			ECLASS E_IUSE E_REQUIRED_USE E_DEPEND E_RDEPEND E_PDEPEND \
+			E_HDEPEND PROVIDES_EXCLUDE REQUIRES_EXCLUDE
 
 		if [[ $PORTAGE_DEBUG != 1 || ${-/x/} != $- ]] ; then
 			source "$EBUILD" || die "error sourcing ebuild"
@@ -311,37 +588,45 @@ EXPORT_FUNCTIONS() {
 			set +x
 		fi
 
-		[[ -n $EAPI ]] || EAPI=0
+		if ___eapi_enables_failglob_in_global_scope; then
+			shopt -u failglob
+		fi
 
-		if has "$EAPI" 0 1 2 3 3_pre2 ; then
+		if [[ "${EBUILD_PHASE}" != "depend" ]] ; then
+			RESTRICT=${PORTAGE_RESTRICT}
+			[[ -e $PORTAGE_BUILDDIR/.ebuild_changed ]] && \
+			rm "$PORTAGE_BUILDDIR/.ebuild_changed"
+		fi
+
+		[ "${EAPI+set}" = set ] || EAPI=0
+
+		# export EAPI for helpers (especially since we unset it above)
+		export EAPI
+
+		if ___eapi_has_RDEPEND_DEPEND_fallback; then
 			export RDEPEND=${RDEPEND-${DEPEND}}
 			debug-print "RDEPEND: not set... Setting to: ${DEPEND}"
 		fi
 
-		# remember ebuild variables
-		OIUSE="${IUSE}"
-		ODEPEND="${DEPEND}"
-		ORDEPEND="${RDEPEND}"
-		OPDEPEND="${PDEPEND}"
-		OREQUIRED_USE="${REQUIRED_USE}"
-
 		# add in dependency info from eclasses
-		IUSE="${IUSE} ${E_IUSE}"
-		DEPEND="${DEPEND} ${E_DEPEND}"
-		RDEPEND="${RDEPEND} ${E_RDEPEND}"
-		PDEPEND="${PDEPEND} ${E_PDEPEND}"
-		REQUIRED_USE="${REQUIRED_USE} ${E_REQUIRED_USE}"
+		IUSE+="${IUSE:+ }${E_IUSE}"
+		DEPEND+="${DEPEND:+ }${E_DEPEND}"
+		RDEPEND+="${RDEPEND:+ }${E_RDEPEND}"
+		PDEPEND+="${PDEPEND:+ }${E_PDEPEND}"
+		HDEPEND+="${HDEPEND:+ }${E_HDEPEND}"
+		REQUIRED_USE+="${REQUIRED_USE:+ }${E_REQUIRED_USE}"
 		
-#		unset ECLASS E_IUSE E_REQUIRED_USE E_DEPEND E_RDEPEND E_PDEPEND 
+		unset ECLASS E_IUSE E_REQUIRED_USE E_DEPEND E_RDEPEND E_PDEPEND E_HDEPEND \
+			__INHERITED_QA_CACHE
 
 		# alphabetically ordered by $EBUILD_PHASE value
-		case "$EAPI" in
+		case ${EAPI} in
 			0|1)
 				_valid_phases="src_compile pkg_config pkg_info src_install
 					pkg_nofetch pkg_postinst pkg_postrm pkg_preinst pkg_prerm
 					pkg_setup src_test src_unpack"
 				;;
-			2|3|3_pre2)
+			2|3)
 				_valid_phases="src_compile pkg_config src_configure pkg_info
 					src_install pkg_nofetch pkg_postinst pkg_postrm pkg_preinst
 					src_prepare pkg_prerm pkg_setup src_test src_unpack"
@@ -363,3 +648,126 @@ EXPORT_FUNCTIONS() {
 		[[ -n $DEFINED_PHASES ]] || DEFINED_PHASES=-
 
 		unset _f _valid_phases
+
+		if [[ $EBUILD_PHASE != depend ]] ; then
+
+			if has distcc $FEATURES ; then
+				[[ -n $DISTCC_LOG ]] && addwrite "${DISTCC_LOG%/*}"
+			fi
+
+			if has ccache $FEATURES ; then
+
+				if [[ -n $CCACHE_DIR ]] ; then
+					addread "$CCACHE_DIR"
+					addwrite "$CCACHE_DIR"
+				fi
+
+				[[ -n $CCACHE_SIZE ]] && ccache -M $CCACHE_SIZE &> /dev/null
+			fi
+
+			if [[ -n $QA_PREBUILT ]] ; then
+
+				# these ones support fnmatch patterns
+				QA_EXECSTACK+=" $QA_PREBUILT"
+				QA_TEXTRELS+=" $QA_PREBUILT"
+				QA_WX_LOAD+=" $QA_PREBUILT"
+
+				# these ones support regular expressions, so translate
+				# fnmatch patterns to regular expressions
+				for x in QA_DT_NEEDED QA_FLAGS_IGNORED QA_PRESTRIPPED QA_SONAME ; do
+					if [[ $(declare -p $x 2>/dev/null) = declare\ -a* ]] ; then
+						eval "$x=(\"\${$x[@]}\" ${QA_PREBUILT//\*/.*})"
+					else
+						eval "$x+=\" ${QA_PREBUILT//\*/.*}\""
+					fi
+				done
+
+				unset x
+			fi
+
+			# This needs to be exported since prepstrip is a separate shell script.
+			[[ -n $QA_PRESTRIPPED ]] && export QA_PRESTRIPPED
+			eval "[[ -n \$QA_PRESTRIPPED_${ARCH/-/_} ]] && \
+				export QA_PRESTRIPPED_${ARCH/-/_}"
+		fi
+	fi
+fi
+
+# unset USE_EXPAND variables that contain only the special "*" token
+for x in ${USE_EXPAND} ; do
+	[ "${!x}" == "*" ] && unset ${x}
+done
+unset x
+
+if has nostrip ${FEATURES} ${RESTRICT} || has strip ${RESTRICT}
+then
+	export DEBUGBUILD=1
+fi
+
+if [[ $EBUILD_PHASE = depend ]] ; then
+	export SANDBOX_ON="0"
+	set -f
+
+	if [ -n "${dbkey}" ] ; then
+		if [ ! -d "${dbkey%/*}" ]; then
+			install -d -g ${PORTAGE_GID} -m2775 "${dbkey%/*}"
+		fi
+		# Make it group writable. 666&~002==664
+		umask 002
+	fi
+
+	auxdbkeys="DEPEND RDEPEND SLOT SRC_URI RESTRICT HOMEPAGE LICENSE
+		DESCRIPTION KEYWORDS INHERITED IUSE REQUIRED_USE PDEPEND PROVIDE EAPI
+		PROPERTIES DEFINED_PHASES HDEPEND UNUSED_04
+		UNUSED_03 UNUSED_02 UNUSED_01"
+
+	if ! ___eapi_has_HDEPEND; then
+		unset HDEPEND
+	fi
+
+	# The extra $(echo) commands remove newlines.
+	if [ -n "${dbkey}" ] ; then
+		> "${dbkey}"
+		for f in ${auxdbkeys} ; do
+			echo $(echo ${!f}) >> "${dbkey}" || exit $?
+		done
+	else
+		for f in ${auxdbkeys} ; do
+			eval "echo \$(echo \${!f}) 1>&${PORTAGE_PIPE_FD}" || exit $?
+		done
+		eval "exec ${PORTAGE_PIPE_FD}>&-"
+	fi
+	set +f
+else
+	# Note: readonly variables interfere with __preprocess_ebuild_env(), so
+	# declare them only after it has already run.
+	declare -r $PORTAGE_READONLY_METADATA $PORTAGE_READONLY_VARS
+	if ___eapi_has_prefix_variables; then
+		declare -r ED EPREFIX EROOT
+	fi
+
+	# If ${EBUILD_FORCE_TEST} == 1 and USE came from ${T}/environment
+	# then it might not have USE=test like it's supposed to here.
+	if [[ ${EBUILD_PHASE} == test && ${EBUILD_FORCE_TEST} == 1 &&
+		test =~ ${PORTAGE_IUSE} ]] && ! has test ${USE} ; then
+		export USE="${USE} test"
+	fi
+	declare -r USE
+
+	if [[ -n $EBUILD_SH_ARGS ]] ; then
+		(
+			# Don't allow subprocesses to inherit the pipe which
+			# emerge uses to monitor ebuild.sh.
+			if [[ -n ${PORTAGE_PIPE_FD} ]] ; then
+				eval "exec ${PORTAGE_PIPE_FD}>&-"
+				unset PORTAGE_PIPE_FD
+			fi
+			__ebuild_main ${EBUILD_SH_ARGS}
+			exit 0
+		)
+		exit $?
+	fi
+fi
+
+# Do not exit when ebuild.sh is sourced by other scripts.
+true

--- a/share/eclass/eutils.eclass
+++ b/share/eclass/eutils.eclass
@@ -1,6 +1,6 @@
-# Copyright 1999-2012 Gentoo Foundation
+# Copyright 1999-2015 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Header: /var/cvsroot/gentoo-x86/eclass/eutils.eclass,v 1.400 2012/06/20 09:26:50 mgorny Exp $
+# $Header: /var/cvsroot/gentoo-x86/eclass/eutils.eclass,v 1.444 2015/03/20 18:28:11 vapier Exp $
 
 # @ECLASS: eutils.eclass
 # @MAINTAINER:
@@ -15,12 +15,10 @@
 # Due to the nature of this eclass, some functions may have maintainers
 # different from the overall eclass!
 
-if [[ ${___ECLASS_ONCE_EUTILS} != "recur -_+^+_- spank" ]] ; then
-___ECLASS_ONCE_EUTILS="recur -_+^+_- spank"
+if [[ -z ${_EUTILS_ECLASS} ]]; then
+_EUTILS_ECLASS=1
 
-inherit multilib toolchain-funcs user
-
-DESCRIPTION="Based on the ${ECLASS} eclass"
+inherit multilib toolchain-funcs
 
 if has "${EAPI:-0}" 0 1 2; then
 
@@ -116,7 +114,7 @@ esvn_clean() {
 # @CODE
 estack_push() {
 	[[ $# -eq 0 ]] && die "estack_push: incorrect # of arguments"
-	local stack_name="__ESTACK_$1__" ; shift
+	local stack_name="_ESTACK_$1_" ; shift
 	eval ${stack_name}+=\( \"\$@\" \)
 }
 
@@ -129,23 +127,94 @@ estack_push() {
 estack_pop() {
 	[[ $# -eq 0 || $# -gt 2 ]] && die "estack_pop: incorrect # of arguments"
 
-	# We use the fugly __estack_xxx var names to avoid collision with
+	# We use the fugly _estack_xxx var names to avoid collision with
 	# passing back the return value.  If we used "local i" and the
 	# caller ran `estack_pop ... i`, we'd end up setting the local
-	# copy of "i" rather than the caller's copy.  The __estack_xxx
+	# copy of "i" rather than the caller's copy.  The _estack_xxx
 	# garbage is preferable to using $1/$2 everywhere as that is a
 	# bit harder to read.
-	local __estack_name="__ESTACK_$1__" ; shift
-	local __estack_retvar=$1 ; shift
-	eval local __estack_i=\${#${__estack_name}\[@\]}
+	local _estack_name="_ESTACK_$1_" ; shift
+	local _estack_retvar=$1 ; shift
+	eval local _estack_i=\${#${_estack_name}\[@\]}
 	# Don't warn -- let the caller interpret this as a failure
 	# or as normal behavior (akin to `shift`)
-	[[ $(( --__estack_i )) -eq -1 ]] && return 1
+	[[ $(( --_estack_i )) -eq -1 ]] && return 1
 
-	if [[ -n ${__estack_retvar} ]] ; then
-		eval ${__estack_retvar}=\"\${${__estack_name}\[${__estack_i}\]}\"
+	if [[ -n ${_estack_retvar} ]] ; then
+		eval ${_estack_retvar}=\"\${${_estack_name}\[${_estack_i}\]}\"
 	fi
-	eval unset ${__estack_name}\[${__estack_i}\]
+	eval unset ${_estack_name}\[${_estack_i}\]
+}
+
+# @FUNCTION: evar_push
+# @USAGE: <variable to save> [more vars to save]
+# @DESCRIPTION:
+# This let's you temporarily modify a variable and then restore it (including
+# set vs unset semantics).  Arrays are not supported at this time.
+#
+# This is meant for variables where using `local` does not work (such as
+# exported variables, or only temporarily changing things in a func).
+#
+# For example:
+# @CODE
+#		evar_push LC_ALL
+#		export LC_ALL=C
+#		... do some stuff that needs LC_ALL=C set ...
+#		evar_pop
+#
+#		# You can also save/restore more than one var at a time
+#		evar_push BUTTERFLY IN THE SKY
+#		... do stuff with the vars ...
+#		evar_pop     # This restores just one var, SKY
+#		... do more stuff ...
+#		evar_pop 3   # This pops the remaining 3 vars
+# @CODE
+evar_push() {
+	local var val
+	for var ; do
+		[[ ${!var+set} == "set" ]] \
+			&& val=${!var} \
+			|| val="unset_76fc3c462065bb4ca959f939e6793f94"
+		estack_push evar "${var}" "${val}"
+	done
+}
+
+# @FUNCTION: evar_push_set
+# @USAGE: <variable to save> [new value to store]
+# @DESCRIPTION:
+# This is a handy shortcut to save and temporarily set a variable.  If a value
+# is not specified, the var will be unset.
+evar_push_set() {
+	local var=$1
+	evar_push ${var}
+	case $# in
+	1) unset ${var} ;;
+	2) printf -v "${var}" '%s' "$2" ;;
+	*) die "${FUNCNAME}: incorrect # of args: $*" ;;
+	esac
+}
+
+# @FUNCTION: evar_pop
+# @USAGE: [number of vars to restore]
+# @DESCRIPTION:
+# Restore the variables to the state saved with the corresponding
+# evar_push call.  See that function for more details.
+evar_pop() {
+	local cnt=${1:-bad}
+	case $# in
+	0) cnt=1 ;;
+	1) isdigit "${cnt}" || die "${FUNCNAME}: first arg must be a number: $*" ;;
+	*) die "${FUNCNAME}: only accepts one arg: $*" ;;
+	esac
+
+	local var val
+	while (( cnt-- )) ; do
+		estack_pop evar val || die "${FUNCNAME}: unbalanced push"
+		estack_pop evar var || die "${FUNCNAME}: unbalanced push"
+		[[ ${val} == "unset_76fc3c462065bb4ca959f939e6793f94" ]] \
+			&& unset ${var} \
+			|| printf -v "${var}" '%s' "${val}"
+	done
 }
 
 # @FUNCTION: eshopts_push
@@ -162,7 +231,7 @@ estack_pop() {
 # A common example is to disable shell globbing so that special meaning/care
 # may be used with variables/arguments to custom functions.  That would be:
 # @CODE
-#		eshopts_push -s noglob
+#		eshopts_push -o noglob
 #		for x in ${foo} ; do
 #			if ...some check... ; then
 #				eshopts_pop
@@ -179,7 +248,7 @@ eshopts_push() {
 	else
 		estack_push eshopts $-
 		[[ $# -eq 0 ]] && return 0
-		set "${@/c}" || die "${FUNCNAME}: bad options to set: $*"
+		set "$@" || die "${FUNCNAME}: bad options to set: $*"
 	fi
 }
 
@@ -194,8 +263,8 @@ eshopts_pop() {
 	if [[ ${s} == "shopt -"* ]] ; then
 		eval "${s}" || die "${FUNCNAME}: sanity: invalid shopt options: ${s}"
 	else
-		set +${-/c}     || die "${FUNCNAME}: sanity: invalid shell settings: $-"
-		set -${s/c}   || die "${FUNCNAME}: sanity: unable to restore saved shell settings: ${s}"
+		set +$-     || die "${FUNCNAME}: sanity: invalid shell settings: $-"
+		set -${s}   || die "${FUNCNAME}: sanity: unable to restore saved shell settings: ${s}"
 	fi
 }
 
@@ -218,6 +287,18 @@ eumask_pop() {
 	local s
 	estack_pop eumask s || die "${FUNCNAME}: unbalanced push"
 	umask ${s} || die "${FUNCNAME}: sanity: could not restore umask: ${s}"
+}
+
+# @FUNCTION: isdigit
+# @USAGE: <number> [more numbers]
+# @DESCRIPTION:
+# Return true if all arguments are numbers.
+isdigit() {
+	local d
+	for d ; do
+		[[ ${d:-bad} == *[!0-9]* ]] && return 1
+	done
+	return 0
 }
 
 # @VARIABLE: EPATCH_SOURCE
@@ -263,6 +344,11 @@ EPATCH_MULTI_MSG="Applying various patches (bugfixes/updates) ..."
 # Only require patches to match EPATCH_SUFFIX rather than the extended
 # arch naming style.
 EPATCH_FORCE="no"
+# @VARIABLE: EPATCH_USER_EXCLUDE
+# @DEFAULT_UNSET
+# @DESCRIPTION:
+# List of patches not to apply.	 Note this is only file names,
+# and not the full path.  Globs accepted.
 
 # @FUNCTION: epatch
 # @USAGE: [options] [patches] [dirs of patches]
@@ -270,7 +356,7 @@ EPATCH_FORCE="no"
 # epatch is designed to greatly simplify the application of patches.  It can
 # process patch files directly, or directories of patches.  The patches may be
 # compressed (bzip/gzip/etc...) or plain text.  You generally need not specify
-# the -p option as epatch will automatically attempt -p0 to -p5 until things
+# the -p option as epatch will automatically attempt -p0 to -p4 until things
 # apply successfully.
 #
 # If you do not specify any patches/dirs, then epatch will default to the
@@ -341,8 +427,11 @@ epatch() {
 		local EPATCH_SUFFIX=$1
 
 	elif [[ -d $1 ]] ; then
-		# Some people like to make dirs of patches w/out suffixes (vim)
+		# We have to force sorting to C so that the wildcard expansion is consistent #471666.
+		evar_push_set LC_COLLATE C
+		# Some people like to make dirs of patches w/out suffixes (vim).
 		set -- "$1"/*${EPATCH_SUFFIX:+."${EPATCH_SUFFIX}"}
+		evar_pop
 
 	elif [[ -f ${EPATCH_SOURCE}/$1 ]] ; then
 		# Re-use EPATCH_SOURCE as a search dir
@@ -400,13 +489,22 @@ epatch() {
 		fi
 
 		# Let people filter things dynamically
-		if [[ -n ${EPATCH_EXCLUDE} ]] ; then
+		if [[ -n ${EPATCH_EXCLUDE}${EPATCH_USER_EXCLUDE} ]] ; then
 			# let people use globs in the exclude
 			eshopts_push -o noglob
 
 			local ex
 			for ex in ${EPATCH_EXCLUDE} ; do
 				if [[ ${patchname} == ${ex} ]] ; then
+					einfo "  Skipping ${patchname} due to EPATCH_EXCLUDE ..."
+					eshopts_pop
+					continue 2
+				fi
+			done
+
+			for ex in ${EPATCH_USER_EXCLUDE} ; do
+				if [[ ${patchname} == ${ex} ]] ; then
+					einfo "  Skipping ${patchname} due to EPATCH_USER_EXCLUDE ..."
 					eshopts_pop
 					continue 2
 				fi
@@ -425,6 +523,10 @@ epatch() {
 			einfo "  ${patchname} ..."
 		fi
 
+		# Handle aliased patch command #404447 #461568
+		local patch="patch"
+		eval $(alias patch 2>/dev/null | sed 's:^alias ::')
+
 		# most of the time, there will only be one run per unique name,
 		# but if there are more, make sure we get unique log filenames
 		local STDERR_TARGET="${T}/${patchname}.out"
@@ -432,7 +534,13 @@ epatch() {
 			STDERR_TARGET="${T}/${patchname}-$$.out"
 		fi
 
-		printf "***** %s *****\nPWD: %s\n\n" "${patchname}" "${PWD}" > "${STDERR_TARGET}"
+		printf "***** %s *****\nPWD: %s\nPATCH TOOL: %s -> %s\nVERSION INFO:\n%s\n\n" \
+			"${patchname}" \
+			"${PWD}" \
+			"${patch}" \
+			"$(type -P "${patch}")" \
+			"$(${patch} --version)" \
+			> "${STDERR_TARGET}"
 
 		# Decompress the patch if need be
 		local count=0
@@ -464,15 +572,20 @@ epatch() {
 		# Similar reason, but with relative paths.
 		local rel_paths=$(egrep -n '^[-+]{3} [^	]*[.][.]/' "${PATCH_TARGET}")
 		if [[ -n ${rel_paths} ]] ; then
-			eqawarn "QA Notice: Your patch uses relative paths '../'."
-			eqawarn " In the future this will cause a failure."
-			eqawarn "${rel_paths}"
+			echo
+			eerror "Rejected Patch: ${patchname} !"
+			eerror " ( ${PATCH_TARGET} )"
+			eerror
+			eerror "Your patch uses relative paths '../':"
+			eerror "${rel_paths}"
+			echo
+			die "you need to fix the relative paths in patch"
 		fi
 
 		# Dynamically detect the correct -p# ... i'm lazy, so shoot me :/
 		local patch_cmd
 		while [[ ${count} -lt 5 ]] ; do
-			patch_cmd="${BASH_ALIASES[patch]:-patch} -p${count} ${EPATCH_OPTS}"
+			patch_cmd="${patch} -p${count} ${EPATCH_OPTS}"
 
 			# Generate some useful debug info ...
 			(
@@ -553,7 +666,7 @@ epatch() {
 # @USAGE:
 # @DESCRIPTION:
 # Applies user-provided patches to the source tree. The patches are
-# taken from /etc/portage/patches/<CATEGORY>/<PF|P|PN>/, where the first
+# taken from /etc/portage/patches/<CATEGORY>/<P-PR|P|PN>[:SLOT]/, where the first
 # of these three directories to exist will be the one to use, ignoring
 # any more general directories which might exist as well. They must end
 # in ".patch" to be applied.
@@ -585,7 +698,7 @@ epatch_user() {
 
 	# don't clobber any EPATCH vars that the parent might want
 	local EPATCH_SOURCE check base=${PORTAGE_CONFIGROOT%/}/etc/portage/patches
-	for check in ${CATEGORY}/{${P}-${PR},${P},${PN}}; do
+	for check in ${CATEGORY}/{${P}-${PR},${P},${PN}}{,:${SLOT}}; do
 		EPATCH_SOURCE=${base}/${CTARGET}/${check}
 		[[ -r ${EPATCH_SOURCE} ]] || EPATCH_SOURCE=${base}/${CHOST}/${check}
 		[[ -r ${EPATCH_SOURCE} ]] || EPATCH_SOURCE=${base}/${check}
@@ -596,11 +709,20 @@ epatch_user() {
 			EPATCH_MULTI_MSG="Applying user patches from ${EPATCH_SOURCE} ..." \
 			epatch
 			echo "${EPATCH_SOURCE}" > "${applied}"
+			has epatch_user_death_notice ${EBUILD_DEATH_HOOKS} || EBUILD_DEATH_HOOKS+=" epatch_user_death_notice"
 			return 0
 		fi
 	done
 	echo "none" > "${applied}"
 	return 1
+}
+# @FUNCTION: epatch_user_death_notice
+# @INTERNAL
+# @DESCRIPTION:
+# Include an explicit notice in the die message itself that user patches were
+# applied to this build.
+epatch_user_death_notice() {
+	ewarn "!!! User patches were applied to this build!"
 }
 
 # @FUNCTION: emktemp
@@ -658,7 +780,7 @@ edos2unix() {
 # @CODE
 # binary:   what command does the app run with ?
 # name:     the name that will show up in the menu
-# icon:     give your little like a pretty little icon ...
+# icon:     the icon to use in the menu entry
 #           this can be relative (to /usr/share/pixmaps) or
 #           a full path to an icon
 # type:     what kind of application is this?
@@ -797,10 +919,11 @@ make_desktop_entry() {
 				;;
 		esac
 	fi
-	if [ "${SLOT}" == "0" ] ; then
+	local slot=${SLOT%/*}
+	if [[ ${slot} == "0" ]] ; then
 		local desktop_name="${PN}"
 	else
-		local desktop_name="${PN}-${SLOT}"
+		local desktop_name="${PN}-${slot}"
 	fi
 	local desktop="${T}/$(echo ${exec} | sed 's:[[:space:]/:]:_:g')-${desktop_name}.desktop"
 	#local desktop=${T}/${exec%% *:-${desktop_name}}.desktop
@@ -842,6 +965,14 @@ make_desktop_entry() {
 	) || die "installing desktop file failed"
 }
 
+# @FUNCTION: _eutils_eprefix_init
+# @INTERNAL
+# @DESCRIPTION:
+# Initialized prefix variables for EAPI<3.
+_eutils_eprefix_init() {
+	has "${EAPI:-0}" 0 1 2 && : ${ED:=${D}} ${EPREFIX:=} ${EROOT:=${ROOT}}
+}
+
 # @FUNCTION: validate_desktop_entries
 # @USAGE: [directories]
 # @MAINTAINER:
@@ -849,11 +980,12 @@ make_desktop_entry() {
 # @DESCRIPTION:
 # Validate desktop entries using desktop-file-utils
 validate_desktop_entries() {
-	if [[ -x /usr/bin/desktop-file-validate ]] ; then
+	_eutils_eprefix_init
+	if [[ -x "${EPREFIX}"/usr/bin/desktop-file-validate ]] ; then
 		einfo "Checking desktop entry validity"
 		local directories=""
 		for d in /usr/share/applications $@ ; do
-			[[ -d ${D}${d} ]] && directories="${directories} ${D}${d}"
+			[[ -d ${ED}${d} ]] && directories="${directories} ${ED}${d}"
 		done
 		if [[ -n ${directories} ]] ; then
 			for FILE in $(find ${directories} -name "*\.desktop" \
@@ -861,7 +993,7 @@ validate_desktop_entries() {
 			do
 				local temp=$(desktop-file-validate ${FILE} | grep -v "warning:" | \
 								sed -e "s|error: ||" -e "s|${FILE}:|--|g" )
-				[[ -n $temp ]] && elog ${temp/--/${FILE/${D}/}:}
+				[[ -n $temp ]] && elog ${temp/--/${FILE/${ED}/}:}
 			done
 		fi
 		echo ""
@@ -966,7 +1098,7 @@ _iconins() {
 				size=${2}
 			fi
 			case ${size} in
-			16|22|24|32|36|48|64|72|96|128|192|256)
+			16|22|24|32|36|48|64|72|96|128|192|256|512)
 				size=${size}x${size};;
 			scalable)
 				;;
@@ -1054,7 +1186,7 @@ doicon() {
 # results in: insinto /usr/share/pixmaps
 #             newins foobar.png NEWNAME.png
 #
-# example 2: newicon -s 48 foobar.png NEWNAME.png 
+# example 2: newicon -s 48 foobar.png NEWNAME.png
 # results in: insinto /usr/share/icons/hicolor/48x48/apps
 #             newins foobar.png NEWNAME.png
 # @CODE
@@ -1121,6 +1253,7 @@ strip-linguas() {
 # solution, so instead you can call this from pkg_preinst.  See also the
 # preserve_old_lib_notify function.
 preserve_old_lib() {
+	_eutils_eprefix_init
 	if [[ ${EBUILD_PHASE} != "preinst" ]] ; then
 		eerror "preserve_old_lib() must be called from pkg_preinst() only"
 		die "Invalid preserve_old_lib() usage"
@@ -1132,11 +1265,11 @@ preserve_old_lib() {
 
 	local lib dir
 	for lib in "$@" ; do
-		[[ -e ${ROOT}/${lib} ]] || continue
+		[[ -e ${EROOT}/${lib} ]] || continue
 		dir=${lib%/*}
 		dodir ${dir} || die "dodir ${dir} failed"
-		cp "${ROOT}"/${lib} "${D}"/${lib} || die "cp ${lib} failed"
-		touch "${D}"/${lib}
+		cp "${EROOT}"/${lib} "${ED}"/${lib} || die "cp ${lib} failed"
+		touch "${ED}"/${lib}
 	done
 }
 
@@ -1153,9 +1286,11 @@ preserve_old_lib_notify() {
 	# let portage worry about it
 	has preserve-libs ${FEATURES} && return 0
 
+	_eutils_eprefix_init
+
 	local lib notice=0
 	for lib in "$@" ; do
-		[[ -e ${ROOT}/${lib} ]] || continue
+		[[ -e ${EROOT}/${lib} ]] || continue
 		if [[ ${notice} -eq 0 ]] ; then
 			notice=1
 			ewarn "Old versions of installed libraries were detected on your system."
@@ -1191,6 +1326,7 @@ preserve_old_lib_notify() {
 # Remember that this function isn't terribly intelligent so order of optional
 # flags matter.
 built_with_use() {
+	_eutils_eprefix_init
 	local hidden="no"
 	if [[ $1 == "--hidden" ]] ; then
 		hidden="yes"
@@ -1214,8 +1350,8 @@ built_with_use() {
 	[[ -z ${PKG} ]] && die "Unable to resolve $1 to an installed package"
 	shift
 
-	local USEFILE=${ROOT}/var/db/pkg/${PKG}/USE
-	local IUSEFILE=${ROOT}/var/db/pkg/${PKG}/IUSE
+	local USEFILE=${EROOT}/var/db/pkg/${PKG}/USE
+	local IUSEFILE=${EROOT}/var/db/pkg/${PKG}/IUSE
 
 	# if the IUSE file doesn't exist, the read will error out, we need to handle
 	# this gracefully
@@ -1271,10 +1407,19 @@ epunt_cxx() {
 	local dir=$1
 	[[ -z ${dir} ]] && dir=${S}
 	ebegin "Removing useless C++ checks"
-	local f
-	find "${dir}" -name configure | while read f ; do
-		patch --no-backup-if-mismatch -p0 "${f}" "${PORTDIR}/eclass/ELT-patches/nocxx/nocxx.patch" > /dev/null
-	done
+	local f p any_found
+	while IFS= read -r -d '' f; do
+		for p in "${PORTDIR}"/eclass/ELT-patches/nocxx/*.patch ; do
+			if patch --no-backup-if-mismatch -p1 "${f}" "${p}" >/dev/null ; then
+				any_found=1
+				break
+			fi
+		done
+	done < <(find "${dir}" -name configure -print0)
+
+	if [[ -z ${any_found} ]]; then
+		eqawarn "epunt_cxx called unnecessarily (no C++ checks to punt)."
+	fi
 	eend 0
 }
 
@@ -1286,23 +1431,34 @@ epunt_cxx() {
 # first optionally setting LD_LIBRARY_PATH to the colon-delimited
 # libpaths followed by optionally changing directory to chdir.
 make_wrapper() {
+	_eutils_eprefix_init
 	local wrapper=$1 bin=$2 chdir=$3 libdir=$4 path=$5
 	local tmpwrapper=$(emktemp)
-	# We don't want to quote ${bin} so that people can pass complex
-	# things as $bin ... "./someprog --args"
-	cat << EOF > "${tmpwrapper}"
-#!/bin/sh
-cd "${chdir:-.}"
-if [ -n "${libdir}" ] ; then
-	if [ "\${LD_LIBRARY_PATH+set}" = "set" ] ; then
-		export LD_LIBRARY_PATH="\${LD_LIBRARY_PATH}:${libdir}"
-	else
-		export LD_LIBRARY_PATH="${libdir}"
+
+	(
+	echo '#!/bin/sh'
+	[[ -n ${chdir} ]] && printf 'cd "%s"\n' "${EPREFIX}${chdir}"
+	if [[ -n ${libdir} ]] ; then
+		local var
+		if [[ ${CHOST} == *-darwin* ]] ; then
+			var=DYLD_LIBRARY_PATH
+		else
+			var=LD_LIBRARY_PATH
+		fi
+		cat <<-EOF
+			if [ "\${${var}+set}" = "set" ] ; then
+				export ${var}="\${${var}}:${EPREFIX}${libdir}"
+			else
+				export ${var}="${EPREFIX}${libdir}"
+			fi
+		EOF
 	fi
-fi
-exec ${bin} "\$@"
-EOF
+	# We don't want to quote ${bin} so that people can pass complex
+	# things as ${bin} ... "./someprog --args"
+	printf 'exec %s "$@"\n' "${bin/#\//${EPREFIX}/}"
+	) > "${tmpwrapper}"
 	chmod go+rx "${tmpwrapper}"
+
 	if [[ -n ${path} ]] ; then
 		(
 		exeinto "${path}"
@@ -1373,12 +1529,16 @@ use_if_iuse() {
 # @FUNCTION: usex
 # @USAGE: <USE flag> [true output] [false output] [true suffix] [false suffix]
 # @DESCRIPTION:
+# Proxy to declare usex for package managers or EAPIs that do not provide it
+# and use the package manager implementation when available (i.e. EAPI >= 5).
 # If USE flag is set, echo [true output][true suffix] (defaults to "yes"),
 # otherwise echo [false output][false suffix] (defaults to "no").
-usex() { use "$1" && echo "${2-yes}$4" || echo "${3-no}$5" ; } #382963
+if has "${EAPI:-0}" 0 1 2 3 4; then
+	usex() { use "$1" && echo "${2-yes}$4" || echo "${3-no}$5" ; } #382963
+fi
 
 # @FUNCTION: prune_libtool_files
-# @USAGE: [--all]
+# @USAGE: [--all|--modules]
 # @DESCRIPTION:
 # Locate unnecessary libtool files (.la) and libtool static archives
 # (.a) and remove them from installation image.
@@ -1387,92 +1547,248 @@ usex() { use "$1" && echo "${2-yes}$4" || echo "${3-no}$5" ; } #382963
 # either be performed using pkg-config or doesn't introduce additional
 # flags.
 #
-# If '--all' argument is passed, all .la files are removed. This is
-# usually useful when the package installs plugins and does not use .la
-# files for loading them.
+# If '--modules' argument is passed, .la files for modules (plugins) are
+# removed as well. This is usually useful when the package installs
+# plugins and the plugin loader does not use .la files.
+#
+# If '--all' argument is passed, all .la files are removed without
+# performing any heuristic on them. You shouldn't ever use that,
+# and instead report a bug in the algorithm instead.
 #
 # The .a files are only removed whenever corresponding .la files state
 # that they should not be linked to, i.e. whenever these files
 # correspond to plugins.
 #
-# Note: if your package installs any .pc files, this function implicitly
-# calls pkg-config. You should add it to your DEPEND in that case.
+# Note: if your package installs both static libraries and .pc files
+# which use variable substitution for -l flags, you need to add
+# pkg-config to your DEPEND.
 prune_libtool_files() {
 	debug-print-function ${FUNCNAME} "$@"
 
-	local removing_all opt
+	local removing_all removing_modules opt
+	_eutils_eprefix_init
 	for opt; do
 		case "${opt}" in
 			--all)
 				removing_all=1
+				removing_modules=1
+				;;
+			--modules)
+				removing_modules=1
 				;;
 			*)
 				die "Invalid argument to ${FUNCNAME}(): ${opt}"
 		esac
 	done
 
-	# Create a list of all .pc-covered libs.
-	local pc_libs=()
-	if [[ ! ${removing_all} ]]; then
-		local f
-		local tf=${T}/prune-lt-files.pc
-		local pkgconf=$(tc-getPKG_CONFIG)
-
-		while IFS= read -r -d '' f; do # for all .pc files
-			local arg
-
-			sed -e '/^Requires:/d' "${f}" > "${tf}"
-			for arg in $("${pkgconf}" --libs "${tf}"); do
-				[[ ${arg} == -l* ]] && pc_libs+=( lib${arg#-l}.la )
-			done
-		done < <(find "${D}" -type f -name '*.pc' -print0)
-
-		rm -f "${tf}"
-	fi
-
 	local f
+	local queue=()
 	while IFS= read -r -d '' f; do # for all .la files
 		local archivefile=${f/%.la/.a}
 
-		[[ ${f} != ${archivefile} ]] || die 'regex sanity check failed'
+		# The following check is done by libtool itself.
+		# It helps us avoid removing random files which match '*.la',
+		# see bug #468380.
+		if ! sed -n -e '/^# Generated by .*libtool/q0;4q1' "${f}"; then
+			continue
+		fi
 
-		# Remove static libs we're not supposed to link against.
-		if grep -q '^shouldnotlink=yes$' "${f}"; then
+		[[ ${f} != ${archivefile} ]] || die 'regex sanity check failed'
+		local reason= pkgconfig_scanned=
+		local snotlink=$(sed -n -e 's:^shouldnotlink=::p' "${f}")
+
+		if [[ ${snotlink} == yes ]]; then
+
+			# Remove static libs we're not supposed to link against.
 			if [[ -f ${archivefile} ]]; then
 				einfo "Removing unnecessary ${archivefile#${D%/}} (static plugin)"
-				rm -f "${archivefile}"
+				queue+=( "${archivefile}" )
 			fi
 
 			# The .la file may be used by a module loader, so avoid removing it
 			# unless explicitly requested.
-			[[ ${removing_all} ]] || continue
-		fi
+			if [[ ${removing_modules} ]]; then
+				reason='module'
+			fi
 
-		# Remove .la files when:
-		# - user explicitly wants us to remove all .la files,
-		# - respective static archive doesn't exist,
-		# - they are covered by a .pc file already,
-		# - they don't provide any new information (no libs & no flags).
-		local reason
-		if [[ ${removing_all} ]]; then
-			reason='requested'
-		elif [[ ! -f ${archivefile} ]]; then
-			reason='no static archive'
-		elif has "${f##*/}" "${pc_libs[@]}"; then
-			reason='covered by .pc'
-		elif [[ ! $(sed -nre \
-				"s/^(dependency_libs|inherited_linker_flags)='(.*)'$/\2/p" \
-				"${f}") ]]; then
-			reason='no libs & flags'
-		fi
+		else
+
+			# Remove .la files when:
+			# - user explicitly wants us to remove all .la files,
+			# - respective static archive doesn't exist,
+			# - they are covered by a .pc file already,
+			# - they don't provide any new information (no libs & no flags).
+
+			if [[ ${removing_all} ]]; then
+				reason='requested'
+			elif [[ ! -f ${archivefile} ]]; then
+				reason='no static archive'
+			elif [[ ! $(sed -nre \
+					"s/^(dependency_libs|inherited_linker_flags)='(.*)'$/\2/p" \
+					"${f}") ]]; then
+				reason='no libs & flags'
+			else
+				if [[ ! ${pkgconfig_scanned} ]]; then
+					# Create a list of all .pc-covered libs.
+					local pc_libs=()
+					if [[ ! ${removing_all} ]]; then
+						local pc
+						local tf=${T}/prune-lt-files.pc
+						local pkgconf=$(tc-getPKG_CONFIG)
+
+						while IFS= read -r -d '' pc; do # for all .pc files
+							local arg libs
+
+							# Use pkg-config if available (and works),
+							# fallback to sed.
+							if ${pkgconf} --exists "${pc}" &>/dev/null; then
+								sed -e '/^Requires:/d' "${pc}" > "${tf}"
+								libs=$(${pkgconf} --libs "${tf}")
+							else
+								libs=$(sed -ne 's/^Libs://p' "${pc}")
+							fi
+
+							for arg in ${libs}; do
+								if [[ ${arg} == -l* ]]; then
+									if [[ ${arg} == '*$*' ]]; then
+										eqawarn "${FUNCNAME}: variable substitution likely failed in ${pc}"
+										eqawarn "(arg: ${arg})"
+										eqawarn "Most likely, you need to add virtual/pkgconfig to DEPEND."
+									fi
+
+									pc_libs+=( lib${arg#-l}.la )
+								fi
+							done
+						done < <(find "${D}" -type f -name '*.pc' -print0)
+
+						rm -f "${tf}"
+					fi
+
+					pkgconfig_scanned=1
+				fi # pkgconfig_scanned
+
+				has "${f##*/}" "${pc_libs[@]}" && reason='covered by .pc'
+			fi # removal due to .pc
+
+		fi # shouldnotlink==no
 
 		if [[ ${reason} ]]; then
 			einfo "Removing unnecessary ${f#${D%/}} (${reason})"
-			rm -f "${f}"
+			queue+=( "${f}" )
 		fi
-	done < <(find "${D}" -type f -name '*.la' -print0)
+	done < <(find "${ED}" -xtype f -name '*.la' -print0)
+
+	if [[ ${queue[@]} ]]; then
+		rm -f "${queue[@]}"
+	fi
+}
+
+# @FUNCTION: einstalldocs
+# @DESCRIPTION:
+# Install documentation using DOCS and HTML_DOCS.
+#
+# If DOCS is declared and non-empty, all files listed in it are
+# installed. The files must exist, otherwise the function will fail.
+# In EAPI 4 and subsequent EAPIs DOCS may specify directories as well,
+# in other EAPIs using directories is unsupported.
+#
+# If DOCS is not declared, the files matching patterns given
+# in the default EAPI implementation of src_install will be installed.
+# If this is undesired, DOCS can be set to empty value to prevent any
+# documentation from being installed.
+#
+# If HTML_DOCS is declared and non-empty, all files and/or directories
+# listed in it are installed as HTML docs (using dohtml).
+#
+# Both DOCS and HTML_DOCS can either be an array or a whitespace-
+# separated list. Whenever directories are allowed, '<directory>/.' may
+# be specified in order to install all files within the directory
+# without creating a sub-directory in docdir.
+#
+# Passing additional options to dodoc and dohtml is not supported.
+# If you needed such a thing, you need to call those helpers explicitly.
+einstalldocs() {
+	debug-print-function ${FUNCNAME} "${@}"
+
+	local dodoc_opts=-r
+	has ${EAPI} 0 1 2 3 && dodoc_opts=
+
+	if ! declare -p DOCS &>/dev/null ; then
+		local d
+		for d in README* ChangeLog AUTHORS NEWS TODO CHANGES \
+				THANKS BUGS FAQ CREDITS CHANGELOG ; do
+			if [[ -s ${d} ]] ; then
+				dodoc "${d}" || die
+			fi
+		done
+	elif [[ $(declare -p DOCS) == "declare -a"* ]] ; then
+		if [[ ${DOCS[@]} ]] ; then
+			dodoc ${dodoc_opts} "${DOCS[@]}" || die
+		fi
+	else
+		if [[ ${DOCS} ]] ; then
+			dodoc ${dodoc_opts} ${DOCS} || die
+		fi
+	fi
+
+	if [[ $(declare -p HTML_DOCS 2>/dev/null) == "declare -a"* ]] ; then
+		if [[ ${HTML_DOCS[@]} ]] ; then
+			dohtml -r "${HTML_DOCS[@]}" || die
+		fi
+	else
+		if [[ ${HTML_DOCS} ]] ; then
+			dohtml -r ${HTML_DOCS} || die
+		fi
+	fi
+
+	return 0
 }
 
 check_license() { die "you no longer need this as portage supports ACCEPT_LICENSE itself"; }
+
+# @FUNCTION: optfeature
+# @USAGE: <short description> <package atom to match> [other atoms]
+# @DESCRIPTION:
+# Print out a message suggesting an optional package (or packages) which
+# provide the described functionality
+#
+# The following snippet would suggest app-misc/foo for optional foo support,
+# app-misc/bar or app-misc/baz[bar] for optional bar support
+# and either both app-misc/a and app-misc/b or app-misc/c for alphabet support.
+# @CODE
+#	optfeature "foo support" app-misc/foo
+#	optfeature "bar support" app-misc/bar app-misc/baz[bar]
+#	optfeature "alphabet support" "app-misc/a app-misc/b" app-misc/c
+# @CODE
+optfeature() {
+	debug-print-function ${FUNCNAME} "$@"
+	local i j msg
+	local desc=$1
+	local flag=0
+	shift
+	for i; do
+		for j in ${i}; do
+			if has_version "${j}"; then
+				flag=1
+			else
+				flag=0
+				break
+			fi
+		done
+		if [[ ${flag} -eq 1 ]]; then
+			break
+		fi
+	done
+	if [[ ${flag} -eq 0 ]]; then
+		for i; do
+			msg=" "
+			for j in ${i}; do
+				msg+=" ${j} and"
+			done
+			msg="${msg:0: -4} for ${desc}"
+			elog "${msg}"
+		done
+	fi
+}
 
 fi

--- a/share/isolated-functions.sh
+++ b/share/isolated-functions.sh
@@ -1,0 +1,562 @@
+#!/bin/bash
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+source "${PORTAGE_BIN_PATH:-/usr/lib/portage/bin}/eapi.sh"
+
+# We need this next line for "die" and "assert". It expands
+# It _must_ preceed all the calls to die and assert.
+shopt -s expand_aliases
+alias save_IFS='[ "${IFS:-unset}" != "unset" ] && old_IFS="${IFS}"'
+alias restore_IFS='if [ "${old_IFS:-unset}" != "unset" ]; then IFS="${old_IFS}"; unset old_IFS; else unset IFS; fi'
+
+assert() {
+	local x pipestatus=${PIPESTATUS[*]}
+	for x in $pipestatus ; do
+		[[ $x -eq 0 ]] || die "$@"
+	done
+}
+
+__assert_sigpipe_ok() {
+	# When extracting a tar file like this:
+	#
+	#     bzip2 -dc foo.tar.bz2 | tar xof -
+	#
+	# For some tar files (see bug #309001), tar will
+	# close its stdin pipe when the decompressor still has
+	# remaining data to be written to its stdout pipe. This
+	# causes the decompressor to be killed by SIGPIPE. In
+	# this case, we want to ignore pipe writers killed by
+	# SIGPIPE, and trust the exit status of tar. We refer
+	# to the bash manual section "3.7.5 Exit Status"
+	# which says, "When a command terminates on a fatal
+	# signal whose number is N, Bash uses the value 128+N
+	# as the exit status."
+
+	local x pipestatus=${PIPESTATUS[*]}
+	for x in $pipestatus ; do
+		# Allow SIGPIPE through (128 + 13)
+		if [[ $x -ne 0 && $x -ne ${PORTAGE_SIGPIPE_STATUS:-141} ]]
+		then
+			__helpers_die "$@"
+			return 1
+		fi
+	done
+
+	# Require normal success for the last process (tar).
+	if [[ $x -ne 0 ]]; then
+		__helpers_die "$@"
+		return 1
+	fi
+}
+
+shopt -s extdebug
+
+# __dump_trace([number of funcs on stack to skip],
+#            [whitespacing for filenames],
+#            [whitespacing for line numbers])
+__dump_trace() {
+	local funcname="" sourcefile="" lineno="" s="yes" n p
+	declare -i strip=${1:-1}
+	local filespacing=$2 linespacing=$3
+
+	# The __qa_call() function and anything before it are portage internals
+	# that the user will not be interested in. Therefore, the stack trace
+	# should only show calls that come after __qa_call().
+	(( n = ${#FUNCNAME[@]} - 1 ))
+	(( p = ${#BASH_ARGV[@]} ))
+	while (( n > 0 )) ; do
+		[ "${FUNCNAME[${n}]}" == "__qa_call" ] && break
+		(( p -= ${BASH_ARGC[${n}]} ))
+		(( n-- ))
+	done
+	if (( n == 0 )) ; then
+		(( n = ${#FUNCNAME[@]} - 1 ))
+		(( p = ${#BASH_ARGV[@]} ))
+	fi
+
+	eerror "Call stack:"
+	while (( n > ${strip} )) ; do
+		funcname=${FUNCNAME[${n} - 1]}
+		sourcefile=$(basename "${BASH_SOURCE[${n}]}")
+		lineno=${BASH_LINENO[${n} - 1]}
+		# Display function arguments
+		args=
+		if [[ -n "${BASH_ARGV[@]}" ]]; then
+			for (( j = 1 ; j <= ${BASH_ARGC[${n} - 1]} ; ++j )); do
+				newarg=${BASH_ARGV[$(( p - j - 1 ))]}
+				args="${args:+${args} }'${newarg}'"
+			done
+			(( p -= ${BASH_ARGC[${n} - 1]} ))
+		fi
+		eerror "  $(printf "%${filespacing}s" "${sourcefile}"), line $(printf "%${linespacing}s" "${lineno}"):  Called ${funcname}${args:+ ${args}}"
+		(( n-- ))
+	done
+}
+
+nonfatal() {
+	if ! ___eapi_has_nonfatal; then
+		die "$FUNCNAME() not supported in this EAPI"
+	fi
+	if [[ $# -lt 1 ]]; then
+		die "$FUNCNAME(): Missing argument"
+	fi
+
+	PORTAGE_NONFATAL=1 "$@"
+}
+
+__bashpid() {
+	# The BASHPID variable is new to bash-4.0, so add a hack for older
+	# versions.  This must be used like so:
+	# ${BASHPID:-$(__bashpid)}
+	sh -c 'echo ${PPID}'
+}
+
+__helpers_die() {
+	if ___eapi_helpers_can_die && [[ ${PORTAGE_NONFATAL} != 1 ]]; then
+		die "$@"
+	else
+		echo -e "$@" >&2
+	fi
+}
+
+die() {
+	local IFS=$' \t\n'
+
+	if ___eapi_die_can_respect_nonfatal; then
+		if [[ ${1} == -n ]]; then
+			[[ ${PORTAGE_NONFATAL} == 1 ]] && return 1
+			shift
+		fi
+	fi
+
+	set +e
+	if [ -n "${QA_INTERCEPTORS}" ] ; then
+		# die was called from inside inherit. We need to clean up
+		# QA_INTERCEPTORS since sed is called below.
+		unset -f ${QA_INTERCEPTORS}
+		unset QA_INTERCEPTORS
+	fi
+	local n filespacing=0 linespacing=0
+	# setup spacing to make output easier to read
+	(( n = ${#FUNCNAME[@]} - 1 ))
+	while (( n > 0 )) ; do
+		[ "${FUNCNAME[${n}]}" == "__qa_call" ] && break
+		(( n-- ))
+	done
+	(( n == 0 )) && (( n = ${#FUNCNAME[@]} - 1 ))
+	while (( n > 0 )); do
+		sourcefile=${BASH_SOURCE[${n}]} sourcefile=${sourcefile##*/}
+		lineno=${BASH_LINENO[${n}]}
+		((filespacing < ${#sourcefile})) && filespacing=${#sourcefile}
+		((linespacing < ${#lineno}))     && linespacing=${#lineno}
+		(( n-- ))
+	done
+
+	# When a helper binary dies automatically in EAPI 4 and later, we don't
+	# get a stack trace, so at least report the phase that failed.
+	local phase_str=
+	[[ -n $EBUILD_PHASE ]] && phase_str=" ($EBUILD_PHASE phase)"
+	eerror "ERROR: ${CATEGORY}/${PF}::${PORTAGE_REPO_NAME} failed${phase_str}:"
+	eerror "  ${*:-(no error message)}"
+	eerror
+	# __dump_trace is useless when the main script is a helper binary
+	local main_index
+	(( main_index = ${#BASH_SOURCE[@]} - 1 ))
+	if has ${BASH_SOURCE[$main_index]##*/} ebuild.sh misc-functions.sh ; then
+	__dump_trace 2 ${filespacing} ${linespacing}
+	eerror "  $(printf "%${filespacing}s" "${BASH_SOURCE[1]##*/}"), line $(printf "%${linespacing}s" "${BASH_LINENO[0]}"):  Called die"
+	eerror "The specific snippet of code:"
+	# This scans the file that called die and prints out the logic that
+	# ended in the call to die.  This really only handles lines that end
+	# with '|| die' and any preceding lines with line continuations (\).
+	# This tends to be the most common usage though, so let's do it.
+	# Due to the usage of appending to the hold space (even when empty),
+	# we always end up with the first line being a blank (thus the 2nd sed).
+	sed -n \
+		-e "# When we get to the line that failed, append it to the
+		    # hold space, move the hold space to the pattern space,
+		    # then print out the pattern space and quit immediately
+		    ${BASH_LINENO[0]}{H;g;p;q}" \
+		-e '# If this line ends with a line continuation, append it
+		    # to the hold space
+		    /\\$/H' \
+		-e '# If this line does not end with a line continuation,
+		    # erase the line and set the hold buffer to it (thus
+		    # erasing the hold buffer in the process)
+		    /[^\]$/{s:^.*$::;h}' \
+		"${BASH_SOURCE[1]}" \
+		| sed -e '1d' -e 's:^:RETAIN-LEADING-SPACE:' \
+		| while read -r n ; do eerror "  ${n#RETAIN-LEADING-SPACE}" ; done
+	eerror
+	fi
+	eerror "If you need support, post the output of \`emerge --info '=${CATEGORY}/${PF}::${PORTAGE_REPO_NAME}'\`,"
+	eerror "the complete build log and the output of \`emerge -pqv '=${CATEGORY}/${PF}::${PORTAGE_REPO_NAME}'\`."
+
+	# Only call die hooks here if we are executed via ebuild.sh or
+	# misc-functions.sh, since those are the only cases where the environment
+	# contains the hook functions. When necessary (like for __helpers_die), die
+	# hooks are automatically called later by a misc-functions.sh invocation.
+	if has ${BASH_SOURCE[$main_index]##*/} ebuild.sh misc-functions.sh && \
+		[[ ${EBUILD_PHASE} != depend ]] ; then
+		local x
+		for x in $EBUILD_DEATH_HOOKS; do
+			${x} "$@" >&2 1>&2
+		done
+		> "$PORTAGE_BUILDDIR/.die_hooks"
+	fi
+
+	if [[ -n ${PORTAGE_LOG_FILE} ]] ; then
+		eerror "The complete build log is located at '${PORTAGE_LOG_FILE}'."
+		if [[ ${PORTAGE_LOG_FILE} != ${T}/* ]] && \
+			! has fail-clean ${FEATURES} ; then
+			# Display path to symlink in ${T}, as requested in bug #412865.
+			local log_ext=log
+			[[ ${PORTAGE_LOG_FILE} != *.log ]] && log_ext+=.${PORTAGE_LOG_FILE##*.}
+			eerror "For convenience, a symlink to the build log is located at '${T}/build.${log_ext}'."
+		fi
+	fi
+	if [ -f "${T}/environment" ] ; then
+		eerror "The ebuild environment file is located at '${T}/environment'."
+	elif [ -d "${T}" ] ; then
+		{
+			set
+			export
+		} > "${T}/die.env"
+		eerror "The ebuild environment file is located at '${T}/die.env'."
+	fi
+	eerror "Working directory: '$(pwd)'"
+	eerror "S: '${S}'"
+
+	[[ -n $PORTAGE_EBUILD_EXIT_FILE ]] && > "$PORTAGE_EBUILD_EXIT_FILE"
+	[[ -n $PORTAGE_IPC_DAEMON ]] && "$PORTAGE_BIN_PATH"/ebuild-ipc exit 1
+
+	# subshell die support
+	[[ ${BASHPID:-$(__bashpid)} == ${EBUILD_MASTER_PID} ]] || kill -s SIGTERM ${EBUILD_MASTER_PID}
+	exit 1
+}
+
+__quiet_mode() {
+	[[ ${PORTAGE_QUIET} -eq 1 ]]
+}
+
+__vecho() {
+	__quiet_mode || echo "$@"
+}
+
+# Internal logging function, don't use this in ebuilds
+__elog_base() {
+	local messagetype
+	[ -z "${1}" -o -z "${T}" -o ! -d "${T}/logging" ] && return 1
+	case "${1}" in
+		INFO|WARN|ERROR|LOG|QA)
+			messagetype="${1}"
+			shift
+			;;
+		*)
+			__vecho -e " ${BAD}*${NORMAL} Invalid use of internal function __elog_base(), next message will not be logged"
+			return 1
+			;;
+	esac
+	echo -e "$@" | while read -r ; do
+		echo "$messagetype $REPLY" >> \
+			"${T}/logging/${EBUILD_PHASE:-other}"
+	done
+	return 0
+}
+
+eqawarn() {
+	__elog_base QA "$*"
+	[[ ${RC_ENDCOL} != "yes" && ${LAST_E_CMD} == "ebegin" ]] && echo
+	echo -e "$@" | while read -r ; do
+		__vecho " $WARN*$NORMAL $REPLY" >&2
+	done
+	LAST_E_CMD="eqawarn"
+	return 0
+}
+
+elog() {
+	__elog_base LOG "$*"
+	[[ ${RC_ENDCOL} != "yes" && ${LAST_E_CMD} == "ebegin" ]] && echo
+	echo -e "$@" | while read -r ; do
+		echo " $GOOD*$NORMAL $REPLY"
+	done
+	LAST_E_CMD="elog"
+	return 0
+}
+
+einfo() {
+	__elog_base INFO "$*"
+	[[ ${RC_ENDCOL} != "yes" && ${LAST_E_CMD} == "ebegin" ]] && echo
+	echo -e "$@" | while read -r ; do
+		echo " $GOOD*$NORMAL $REPLY"
+	done
+	LAST_E_CMD="einfo"
+	return 0
+}
+
+einfon() {
+	__elog_base INFO "$*"
+	[[ ${RC_ENDCOL} != "yes" && ${LAST_E_CMD} == "ebegin" ]] && echo
+	echo -ne " ${GOOD}*${NORMAL} $*"
+	LAST_E_CMD="einfon"
+	return 0
+}
+
+ewarn() {
+	__elog_base WARN "$*"
+	[[ ${RC_ENDCOL} != "yes" && ${LAST_E_CMD} == "ebegin" ]] && echo
+	echo -e "$@" | while read -r ; do
+		echo " $WARN*$NORMAL $RC_INDENTATION$REPLY" >&2
+	done
+	LAST_E_CMD="ewarn"
+	return 0
+}
+
+eerror() {
+	__elog_base ERROR "$*"
+	[[ ${RC_ENDCOL} != "yes" && ${LAST_E_CMD} == "ebegin" ]] && echo
+	echo -e "$@" | while read -r ; do
+		echo " $BAD*$NORMAL $RC_INDENTATION$REPLY" >&2
+	done
+	LAST_E_CMD="eerror"
+	return 0
+}
+
+ebegin() {
+	local msg="$*" dots spaces=${RC_DOT_PATTERN//?/ }
+	if [[ -n ${RC_DOT_PATTERN} ]] ; then
+		dots=$(printf "%$(( COLS - 3 - ${#RC_INDENTATION} - ${#msg} - 7 ))s" '')
+		dots=${dots//${spaces}/${RC_DOT_PATTERN}}
+		msg="${msg}${dots}"
+	else
+		msg="${msg} ..."
+	fi
+	einfon "${msg}"
+	[[ ${RC_ENDCOL} == "yes" ]] && echo
+	LAST_E_LEN=$(( 3 + ${#RC_INDENTATION} + ${#msg} ))
+	LAST_E_CMD="ebegin"
+	return 0
+}
+
+__eend() {
+	local retval=${1:-0} efunc=${2:-eerror} msg
+	shift 2
+
+	if [[ ${retval} == "0" ]] ; then
+		msg="${BRACKET}[ ${GOOD}ok${BRACKET} ]${NORMAL}"
+	else
+		if [[ -n $* ]] ; then
+			${efunc} "$*"
+		fi
+		msg="${BRACKET}[ ${BAD}!!${BRACKET} ]${NORMAL}"
+	fi
+
+	if [[ ${RC_ENDCOL} == "yes" ]] ; then
+		echo -e "${ENDCOL} ${msg}"
+	else
+		[[ ${LAST_E_CMD} == ebegin ]] || LAST_E_LEN=0
+		printf "%$(( COLS - LAST_E_LEN - 7 ))s%b\n" '' "${msg}"
+	fi
+
+	return ${retval}
+}
+
+eend() {
+	local retval=${1:-0}
+	shift
+
+	__eend ${retval} eerror "$*"
+
+	LAST_E_CMD="eend"
+	return ${retval}
+}
+
+__unset_colors() {
+	COLS=80
+	ENDCOL=
+
+	GOOD=
+	WARN=
+	BAD=
+	NORMAL=
+	HILITE=
+	BRACKET=
+}
+
+__set_colors() {
+	COLS=${COLUMNS:-0}      # bash's internal COLUMNS variable
+	# Avoid wasteful stty calls during the "depend" phases.
+	# If stdout is a pipe, the parent process can export COLUMNS
+	# if it's relevant. Use an extra subshell for stty calls, in
+	# order to redirect "/dev/tty: No such device or address"
+	# error from bash to /dev/null.
+	[[ $COLS == 0 && $EBUILD_PHASE != depend ]] && \
+		COLS=$(set -- $( ( stty size </dev/tty ) 2>/dev/null || echo 24 80 ) ; echo $2)
+	(( COLS > 0 )) || (( COLS = 80 ))
+
+	# Now, ${ENDCOL} will move us to the end of the
+	# column;  irregardless of character width
+	ENDCOL=$'\e[A\e['$(( COLS - 8 ))'C'
+	if [ -n "${PORTAGE_COLORMAP}" ] ; then
+		eval ${PORTAGE_COLORMAP}
+	else
+		GOOD=$'\e[32;01m'
+		WARN=$'\e[33;01m'
+		BAD=$'\e[31;01m'
+		HILITE=$'\e[36;01m'
+		BRACKET=$'\e[34;01m'
+		NORMAL=$'\e[0m'
+	fi
+}
+
+RC_ENDCOL="yes"
+RC_INDENTATION=''
+RC_DEFAULT_INDENT=2
+RC_DOT_PATTERN=''
+
+case "${NOCOLOR:-false}" in
+	yes|true)
+		__unset_colors
+		;;
+	no|false)
+		__set_colors
+		;;
+esac
+
+if [[ -z ${USERLAND} ]] ; then
+	case $(uname -s) in
+	*BSD|DragonFly)
+		export USERLAND="BSD"
+		;;
+	*)
+		export USERLAND="GNU"
+		;;
+	esac
+fi
+
+if [[ -z ${XARGS} ]] ; then
+	case ${USERLAND} in
+	BSD)
+		export XARGS="xargs"
+		;;
+	*)
+		export XARGS="xargs -r"
+		;;
+	esac
+fi
+
+hasq() {
+	has $EBUILD_PHASE prerm postrm || eqawarn \
+		"QA Notice: The 'hasq' function is deprecated (replaced by 'has')"
+	has "$@"
+}
+
+hasv() {
+	if has "$@" ; then
+		echo "$1"
+		return 0
+	fi
+	return 1
+}
+
+has() {
+	local needle=$1
+	shift
+
+	local x
+	for x in "$@"; do
+		[ "${x}" = "${needle}" ] && return 0
+	done
+	return 1
+}
+
+__repo_attr() {
+	local appropriate_section=0 exit_status=1 line saved_extglob_shopt=$(shopt -p extglob)
+	shopt -s extglob
+	while read line; do
+		[[ ${appropriate_section} == 0 && ${line} == "[$1]" ]] && appropriate_section=1 && continue
+		[[ ${appropriate_section} == 1 && ${line} == "["*"]" ]] && appropriate_section=0 && continue
+		# If a conditional expression like [[ ${line} == $2*( )=* ]] is used
+		# then bash-3.2 produces an error like the following when the file is
+		# sourced: syntax error in conditional expression: unexpected token `('
+		# Therefore, use a regular expression for compatibility.
+		if [[ ${appropriate_section} == 1 && ${line} =~ ^${2}[[:space:]]*= ]]; then
+			echo "${line##$2*( )=*( )}"
+			exit_status=0
+			break
+		fi
+	done <<< "${PORTAGE_REPOSITORIES}"
+	eval "${saved_extglob_shopt}"
+	return ${exit_status}
+}
+
+# eqaquote <string>
+#
+# outputs parameter escaped for quoting
+__eqaquote() {
+	local v=${1} esc=''
+
+	# quote backslashes
+	v=${v//\\/\\\\}
+	# quote the quotes
+	v=${v//\"/\\\"}
+	# quote newlines
+	while read -r; do
+		echo -n "${esc}${REPLY}"
+		esc='\n'
+	done <<<"${v}"
+}
+
+# eqatag <tag> [-v] [<key>=<value>...] [/<relative-path>...]
+#
+# output (to qa.log):
+# - tag: <tag>
+#   data:
+#     <key1>: "<value1>"
+#     <key2>: "<value2>"
+#   files:
+#     - "<path1>"
+#     - "<path2>"
+__eqatag() {
+	local tag i filenames=() data=() verbose=
+
+	if [[ ${1} == -v ]]; then
+		verbose=1
+		shift
+	fi
+
+	tag=${1}
+	shift
+	[[ -n ${tag} ]] || die "${FUNCNAME}: no tag specified"
+
+	# collect data & filenames
+	for i; do
+		if [[ ${i} == /* ]]; then
+			filenames+=( "${i}" )
+			[[ -n ${verbose} ]] && eqawarn "  ${i}"
+		elif [[ ${i} == *=* ]]; then
+			data+=( "${i}" )
+		else
+			die "${FUNCNAME}: invalid parameter: ${i}"
+		fi
+	done
+
+	(
+		echo "- tag: ${tag}"
+		if [[ ${data[@]} ]]; then
+			echo "  data:"
+			for i in "${data[@]}"; do
+				echo "    ${i%%=*}: \"$(__eqaquote "${i#*=}")\""
+			done
+		fi
+		if [[ ${filenames[@]} ]]; then
+			echo "  files:"
+			for i in "${filenames[@]}"; do
+				echo "    - \"$(__eqaquote "${i}")\""
+			done
+		fi
+	) >> "${T}"/qa.log
+}
+
+true

--- a/share/phase-functions.sh
+++ b/share/phase-functions.sh
@@ -1,0 +1,1016 @@
+#!/bin/bash
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+# Hardcoded bash lists are needed for backward compatibility with
+# <portage-2.1.4 since they assume that a newly installed version
+# of ebuild.sh will work for pkg_postinst, pkg_prerm, and pkg_postrm
+# when portage is upgrading itself.
+
+PORTAGE_READONLY_METADATA="DEFINED_PHASES DEPEND DESCRIPTION
+	EAPI HDEPEND HOMEPAGE INHERITED IUSE REQUIRED_USE KEYWORDS LICENSE
+	PDEPEND PROVIDE RDEPEND REPOSITORY RESTRICT SLOT SRC_URI"
+
+PORTAGE_READONLY_VARS="D EBUILD EBUILD_PHASE EBUILD_PHASE_FUNC \
+	EBUILD_SH_ARGS ECLASSDIR EMERGE_FROM FILESDIR MERGE_TYPE \
+	PM_EBUILD_HOOK_DIR \
+	PORTAGE_ACTUAL_DISTDIR PORTAGE_ARCHLIST PORTAGE_BASHRC  \
+	PORTAGE_BINPKG_FILE PORTAGE_BINPKG_TAR_OPTS PORTAGE_BINPKG_TMPFILE \
+	PORTAGE_BIN_PATH PORTAGE_BUILDDIR PORTAGE_BUILD_GROUP \
+	PORTAGE_BUILD_USER PORTAGE_BUNZIP2_COMMAND \
+	PORTAGE_BZIP2_COMMAND PORTAGE_COLORMAP PORTAGE_CONFIGROOT \
+	PORTAGE_DEBUG PORTAGE_DEPCACHEDIR PORTAGE_EBUILD_EXIT_FILE \
+	PORTAGE_ECLASS_LOCATIONS \
+	PORTAGE_GID PORTAGE_GRPNAME PORTAGE_INST_GID PORTAGE_INST_UID \
+	PORTAGE_INTERNAL_CALLER PORTAGE_IPC_DAEMON PORTAGE_IUSE PORTAGE_LOG_FILE \
+	PORTAGE_MUTABLE_FILTERED_VARS PORTAGE_OVERRIDE_EPREFIX \
+	PORTAGE_PYM_PATH PORTAGE_PYTHON PORTAGE_PYTHONPATH \
+	PORTAGE_READONLY_METADATA PORTAGE_READONLY_VARS \
+	PORTAGE_REPO_NAME PORTAGE_REPOSITORIES PORTAGE_RESTRICT \
+	PORTAGE_SAVED_READONLY_VARS PORTAGE_SIGPIPE_STATUS \
+	PORTAGE_TMPDIR PORTAGE_UPDATE_ENV PORTAGE_USERNAME \
+	PORTAGE_VERBOSE PORTAGE_WORKDIR_MODE PORTAGE_XATTR_EXCLUDE \
+	PORTDIR \
+	REPLACING_VERSIONS REPLACED_BY_VERSION T WORKDIR \
+	__PORTAGE_HELPER __PORTAGE_TEST_HARDLINK_LOCKS"
+
+PORTAGE_SAVED_READONLY_VARS="A CATEGORY P PF PN PR PV PVR"
+
+# Variables that portage sets but doesn't mark readonly.
+# In order to prevent changed values from causing unexpected
+# interference, they are filtered out of the environment when
+# it is saved or loaded (any mutations do not persist).
+PORTAGE_MUTABLE_FILTERED_VARS="AA HOSTNAME"
+
+# @FUNCTION: __filter_readonly_variables
+# @DESCRIPTION: [--filter-sandbox] [--allow-extra-vars]
+# Read an environment from stdin and echo to stdout while filtering variables
+# with names that are known to cause interference:
+#
+#   * some specific variables for which bash does not allow assignment
+#   * some specific variables that affect portage or sandbox behavior
+#   * variable names that begin with a digit or that contain any
+#     non-alphanumeric characters that are not be supported by bash
+#
+# --filter-sandbox causes all SANDBOX_* variables to be filtered, which
+# is only desired in certain cases, such as during preprocessing or when
+# saving environment.bz2 for a binary or installed package.
+#
+# --filter-features causes the special FEATURES variable to be filtered.
+# Generally, we want it to persist between phases since the user might
+# want to modify it via bashrc to enable things like splitdebug and
+# installsources for specific packages. They should be able to modify it
+# in pre_pkg_setup() and have it persist all the way through the install
+# phase. However, if FEATURES exist inside environment.bz2 then they
+# should be overridden by current settings.
+#
+# --filter-locale causes locale related variables such as LANG and LC_*
+# variables to be filtered. These variables should persist between phases,
+# in case they are modified by the ebuild. However, the current user
+# settings should be used when loading the environment from a binary or
+# installed package.
+#
+# --filter-path causes the PATH variable to be filtered. This variable
+# should persist between phases, in case it is modified by the ebuild.
+# However, old settings should be overridden when loading the
+# environment from a binary or installed package.
+#
+# ---allow-extra-vars causes some extra vars to be allowd through, such
+# as ${PORTAGE_SAVED_READONLY_VARS} and ${PORTAGE_MUTABLE_FILTERED_VARS}.
+# This is enabled automatically if EMERGE_FROM=binary, since it preserves
+# variables from when the package was originally built.
+#
+# In bash-3.2_p20+ an attempt to assign BASH_*, FUNCNAME, GROUPS or any
+# readonly variable cause the shell to exit while executing the "source"
+# builtin command. To avoid this problem, this function filters those
+# variables out and discards them. See bug #190128.
+__filter_readonly_variables() {
+	local x filtered_vars
+	local readonly_bash_vars="BASHOPTS BASHPID DIRSTACK EUID
+		FUNCNAME GROUPS PIPESTATUS PPID SHELLOPTS UID"
+	local bash_misc_vars="BASH BASH_.* COLUMNS COMP_WORDBREAKS HISTCMD
+		HISTFILE HOSTNAME HOSTTYPE IFS LINENO MACHTYPE OLDPWD
+		OPTERR OPTIND OSTYPE POSIXLY_CORRECT PS4 PWD RANDOM
+		SECONDS SHLVL _"
+	local filtered_sandbox_vars="SANDBOX_ACTIVE SANDBOX_BASHRC
+		SANDBOX_DEBUG_LOG SANDBOX_DISABLED SANDBOX_LIB
+		SANDBOX_LOG SANDBOX_ON"
+	# Untrusted due to possible application of package renames to binpkgs
+	local binpkg_untrusted_vars="CATEGORY P PF PN PR PV PVR"
+	local misc_garbage_vars="_portage_filter_opts"
+	filtered_vars="$readonly_bash_vars $bash_misc_vars
+		$PORTAGE_READONLY_VARS $misc_garbage_vars"
+
+	# Don't filter/interfere with prefix variables unless they are
+	# supported by the current EAPI.
+	if ___eapi_has_prefix_variables; then
+		filtered_vars+=" ED EPREFIX EROOT"
+	fi
+
+	if has --filter-sandbox $* ; then
+		filtered_vars="${filtered_vars} SANDBOX_.*"
+	else
+		filtered_vars="${filtered_vars} ${filtered_sandbox_vars}"
+	fi
+	if has --filter-features $* ; then
+		filtered_vars="${filtered_vars} FEATURES PORTAGE_FEATURES"
+	fi
+	if has --filter-path $* ; then
+		filtered_vars+=" PATH"
+	fi
+	if has --filter-locale $* ; then
+		filtered_vars+=" LANG LC_ALL LC_COLLATE
+			LC_CTYPE LC_MESSAGES LC_MONETARY
+			LC_NUMERIC LC_PAPER LC_TIME"
+	fi
+	if ! has --allow-extra-vars $* ; then
+		if [ "${EMERGE_FROM}" = binary ] ; then
+			# preserve additional variables from build time,
+			# while excluding untrusted variables
+			filtered_vars+=" ${binpkg_untrusted_vars}"
+		else
+			filtered_vars+=" ${PORTAGE_SAVED_READONLY_VARS}"
+			filtered_vars+=" ${PORTAGE_MUTABLE_FILTERED_VARS}"
+		fi
+	fi
+
+	"${PORTAGE_PYTHON:-/usr/bin/python}" "${PORTAGE_BIN_PATH}"/filter-bash-environment.py "${filtered_vars}" || die "filter-bash-environment.py failed"
+}
+
+# @FUNCTION: __preprocess_ebuild_env
+# @DESCRIPTION:
+# Filter any readonly variables from ${T}/environment, source it, and then
+# save it via __save_ebuild_env(). This process should be sufficient to prevent
+# any stale variables or functions from an arbitrary environment from
+# interfering with the current environment. This is useful when an existing
+# environment needs to be loaded from a binary or installed package.
+__preprocess_ebuild_env() {
+	local _portage_filter_opts="--filter-features --filter-locale --filter-path --filter-sandbox"
+
+	# If environment.raw is present, this is a signal from the python side,
+	# indicating that the environment may contain stale FEATURES and
+	# SANDBOX_{DENY,PREDICT,READ,WRITE} variables that should be filtered out.
+	# Otherwise, we don't need to filter the environment.
+	[ -f "${T}/environment.raw" ] || return 0
+
+	__filter_readonly_variables $_portage_filter_opts < "${T}"/environment \
+		>> "$T/environment.filtered" || return $?
+	unset _portage_filter_opts
+	mv "${T}"/environment.filtered "${T}"/environment || return $?
+	rm -f "${T}/environment.success" || return $?
+	# WARNING: Code inside this subshell should avoid making assumptions
+	# about variables or functions after source "${T}"/environment has been
+	# called. Any variables that need to be relied upon should already be
+	# filtered out above.
+	(
+		export SANDBOX_ON=1
+		source "${T}/environment" || exit $?
+		# We have to temporarily disable sandbox since the
+		# SANDBOX_{DENY,READ,PREDICT,WRITE} values we've just loaded
+		# may be unusable (triggering in spurious sandbox violations)
+		# until we've merged them with our current values.
+		export SANDBOX_ON=0
+
+		# It's remotely possible that __save_ebuild_env() has been overridden
+		# by the above source command. To protect ourselves, we override it
+		# here with our own version. ${PORTAGE_BIN_PATH} is safe to use here
+		# because it's already filtered above.
+		source "${PORTAGE_BIN_PATH}/save-ebuild-env.sh" || exit $?
+
+		# Rely on __save_ebuild_env() to filter out any remaining variables
+		# and functions that could interfere with the current environment.
+		__save_ebuild_env || exit $?
+		>> "$T/environment.success" || exit $?
+	) > "${T}/environment.filtered"
+	local retval
+	if [ -e "${T}/environment.success" ] ; then
+		__filter_readonly_variables --filter-features < \
+			"${T}/environment.filtered" > "${T}/environment"
+		retval=$?
+	else
+		retval=1
+	fi
+	rm -f "${T}"/environment.{filtered,raw,success}
+	return ${retval}
+}
+
+__ebuild_phase() {
+	declare -F "$1" >/dev/null && __qa_call $1
+}
+
+__ebuild_phase_with_hooks() {
+	local x phase_name=${1}
+	for x in {pre_,,post_}${phase_name} ; do
+		__ebuild_phase ${x}
+	done
+}
+
+__dyn_pretend() {
+	if [[ -e $PORTAGE_BUILDDIR/.pretended ]] ; then
+		__vecho ">>> It appears that '$PF' is already pretended; skipping."
+		__vecho ">>> Remove '$PORTAGE_BUILDDIR/.pretended' to force pretend."
+		return 0
+	fi
+	__ebuild_phase pre_pkg_pretend
+	__ebuild_phase pkg_pretend
+	>> "$PORTAGE_BUILDDIR/.pretended" || \
+		die "Failed to create $PORTAGE_BUILDDIR/.pretended"
+	__ebuild_phase post_pkg_pretend
+}
+
+__dyn_setup() {
+	if [[ -e $PORTAGE_BUILDDIR/.setuped ]] ; then
+		__vecho ">>> It appears that '$PF' is already setup; skipping."
+		__vecho ">>> Remove '$PORTAGE_BUILDDIR/.setuped' to force setup."
+		return 0
+	fi
+	__ebuild_phase pre_pkg_setup
+	__ebuild_phase pkg_setup
+	>> "$PORTAGE_BUILDDIR/.setuped" || \
+		die "Failed to create $PORTAGE_BUILDDIR/.setuped"
+	__ebuild_phase post_pkg_setup
+}
+
+__dyn_unpack() {
+	if [[ -f ${PORTAGE_BUILDDIR}/.unpacked ]] ; then
+		__vecho ">>> WORKDIR is up-to-date, keeping..."
+		return 0
+	fi
+	if [ ! -d "${WORKDIR}" ]; then
+		install -m${PORTAGE_WORKDIR_MODE:-0700} -d "${WORKDIR}" || die "Failed to create dir '${WORKDIR}'"
+	fi
+	cd "${WORKDIR}" || die "Directory change failed: \`cd '${WORKDIR}'\`"
+	__ebuild_phase pre_src_unpack
+	__vecho ">>> Unpacking source..."
+	__ebuild_phase src_unpack
+	>> "$PORTAGE_BUILDDIR/.unpacked" || \
+		die "Failed to create $PORTAGE_BUILDDIR/.unpacked"
+	__vecho ">>> Source unpacked in ${WORKDIR}"
+	__ebuild_phase post_src_unpack
+}
+
+__dyn_clean() {
+	if [ -z "${PORTAGE_BUILDDIR}" ]; then
+		echo "Aborting clean phase because PORTAGE_BUILDDIR is unset!"
+		return 1
+	elif [ ! -d "${PORTAGE_BUILDDIR}" ] ; then
+		return 0
+	fi
+	if has chflags $FEATURES ; then
+		chflags -R noschg,nouchg,nosappnd,nouappnd "${PORTAGE_BUILDDIR}"
+		chflags -R nosunlnk,nouunlnk "${PORTAGE_BUILDDIR}" 2>/dev/null
+	fi
+
+	rm -rf "${PORTAGE_BUILDDIR}/image" "${PORTAGE_BUILDDIR}/homedir"
+	rm -f "${PORTAGE_BUILDDIR}/.installed"
+
+	if [[ $EMERGE_FROM = binary ]] || \
+		! has keeptemp $FEATURES && ! has keepwork $FEATURES ; then
+		rm -rf "${T}"
+	fi
+
+	if [[ $EMERGE_FROM = binary ]] || ! has keepwork $FEATURES; then
+		rm -f "$PORTAGE_BUILDDIR"/.{ebuild_changed,logid,pretended,setuped,unpacked,prepared} \
+			"$PORTAGE_BUILDDIR"/.{configured,compiled,tested,packaged} \
+			"$PORTAGE_BUILDDIR"/.die_hooks \
+			"$PORTAGE_BUILDDIR"/.ipc_{in,out,lock} \
+			"$PORTAGE_BUILDDIR"/.exit_status
+
+		rm -rf "${PORTAGE_BUILDDIR}/build-info"
+		rm -rf "${WORKDIR}"
+	fi
+
+	if [ -f "${PORTAGE_BUILDDIR}/.unpacked" ]; then
+		find "${PORTAGE_BUILDDIR}" -type d ! -regex "^${WORKDIR}" | sort -r | tr "\n" "\0" | $XARGS -0 rmdir &>/dev/null
+	fi
+
+	# do not bind this to doebuild defined DISTDIR; don't trust doebuild, and if mistakes are made it'll
+	# result in it wiping the users distfiles directory (bad).
+	rm -rf "${PORTAGE_BUILDDIR}/distdir"
+
+	# Some kernels, such as Solaris, return EINVAL when an attempt
+	# is made to remove the current working directory.
+	cd "$PORTAGE_BUILDDIR"/../..
+	rmdir "$PORTAGE_BUILDDIR" 2>/dev/null
+
+	true
+}
+
+__abort_handler() {
+	local msg
+	if [ "$2" != "fail" ]; then
+		msg="${EBUILD}: ${1} aborted; exiting."
+	else
+		msg="${EBUILD}: ${1} failed; exiting."
+	fi
+	echo
+	echo "$msg"
+	echo
+	eval ${3}
+	#unset signal handler
+	trap - SIGINT SIGQUIT
+}
+
+__abort_prepare() {
+	__abort_handler src_prepare $1
+	rm -f "$PORTAGE_BUILDDIR/.prepared"
+	exit 1
+}
+
+__abort_configure() {
+	__abort_handler src_configure $1
+	rm -f "$PORTAGE_BUILDDIR/.configured"
+	exit 1
+}
+
+__abort_compile() {
+	__abort_handler "src_compile" $1
+	rm -f "${PORTAGE_BUILDDIR}/.compiled"
+	exit 1
+}
+
+__abort_test() {
+	__abort_handler "__dyn_test" $1
+	rm -f "${PORTAGE_BUILDDIR}/.tested"
+	exit 1
+}
+
+__abort_install() {
+	__abort_handler "src_install" $1
+	rm -rf "${PORTAGE_BUILDDIR}/image"
+	exit 1
+}
+
+__has_phase_defined_up_to() {
+	local phase
+	for phase in unpack prepare configure compile install; do
+		has ${phase} ${DEFINED_PHASES} && return 0
+		[[ ${phase} == $1 ]] && return 1
+	done
+	# We shouldn't actually get here
+	return 1
+}
+
+__dyn_prepare() {
+
+	if [[ -e $PORTAGE_BUILDDIR/.prepared ]] ; then
+		__vecho ">>> It appears that '$PF' is already prepared; skipping."
+		__vecho ">>> Remove '$PORTAGE_BUILDDIR/.prepared' to force prepare."
+		return 0
+	fi
+
+	if [[ -d $S ]] ; then
+		cd "${S}"
+	elif ___eapi_has_S_WORKDIR_fallback; then
+		cd "${WORKDIR}"
+	elif [[ -z ${A} ]] && ! __has_phase_defined_up_to prepare; then
+		cd "${WORKDIR}"
+	else
+		die "The source directory '${S}' doesn't exist"
+	fi
+
+	trap __abort_prepare SIGINT SIGQUIT
+
+	__ebuild_phase pre_src_prepare
+	__vecho ">>> Preparing source in $PWD ..."
+	__ebuild_phase src_prepare
+	>> "$PORTAGE_BUILDDIR/.prepared" || \
+		die "Failed to create $PORTAGE_BUILDDIR/.prepared"
+	__vecho ">>> Source prepared."
+	__ebuild_phase post_src_prepare
+
+	trap - SIGINT SIGQUIT
+}
+
+# @FUNCTION: __start_distcc
+# @DESCRIPTION:
+# Start distcc-pump if necessary.
+__start_distcc() {
+	if has distcc $FEATURES && has distcc-pump $FEATURES ; then
+		if [[ -z $INCLUDE_SERVER_PORT ]] || [[ ! -w $INCLUDE_SERVER_PORT ]] ; then
+			# adding distcc to PATH repeatedly results in fatal distcc recursion :)
+			eval $(pump --startup | grep -v PATH)
+			trap "pump --shutdown >/dev/null" EXIT
+		fi
+	fi
+}
+
+__dyn_configure() {
+
+	if [[ -e $PORTAGE_BUILDDIR/.configured ]] ; then
+		__vecho ">>> It appears that '$PF' is already configured; skipping."
+		__vecho ">>> Remove '$PORTAGE_BUILDDIR/.configured' to force configuration."
+		return 0
+	fi
+
+	if [[ -d $S ]] ; then
+		cd "${S}"
+	elif ___eapi_has_S_WORKDIR_fallback; then
+		cd "${WORKDIR}"
+	elif [[ -z ${A} ]] && ! __has_phase_defined_up_to configure; then
+		cd "${WORKDIR}"
+	else
+		die "The source directory '${S}' doesn't exist"
+	fi
+
+	trap __abort_configure SIGINT SIGQUIT
+	__start_distcc
+
+	__ebuild_phase pre_src_configure
+
+	__vecho ">>> Configuring source in $PWD ..."
+	__ebuild_phase src_configure
+	>> "$PORTAGE_BUILDDIR/.configured" || \
+		die "Failed to create $PORTAGE_BUILDDIR/.configured"
+	__vecho ">>> Source configured."
+
+	__ebuild_phase post_src_configure
+
+	trap - SIGINT SIGQUIT
+}
+
+__dyn_compile() {
+
+	if [[ -e $PORTAGE_BUILDDIR/.compiled ]] ; then
+		__vecho ">>> It appears that '${PF}' is already compiled; skipping."
+		__vecho ">>> Remove '$PORTAGE_BUILDDIR/.compiled' to force compilation."
+		return 0
+	fi
+
+	if [[ -d $S ]] ; then
+		cd "${S}"
+	elif ___eapi_has_S_WORKDIR_fallback; then
+		cd "${WORKDIR}"
+	elif [[ -z ${A} ]] && ! __has_phase_defined_up_to compile; then
+		cd "${WORKDIR}"
+	else
+		die "The source directory '${S}' doesn't exist"
+	fi
+
+	trap __abort_compile SIGINT SIGQUIT
+	__start_distcc
+
+	__ebuild_phase pre_src_compile
+
+	__vecho ">>> Compiling source in $PWD ..."
+	__ebuild_phase src_compile
+	>> "$PORTAGE_BUILDDIR/.compiled" || \
+		die "Failed to create $PORTAGE_BUILDDIR/.compiled"
+	__vecho ">>> Source compiled."
+
+	__ebuild_phase post_src_compile
+
+	trap - SIGINT SIGQUIT
+}
+
+__dyn_test() {
+
+	if [[ -e $PORTAGE_BUILDDIR/.tested ]] ; then
+		__vecho ">>> It appears that ${PN} has already been tested; skipping."
+		__vecho ">>> Remove '${PORTAGE_BUILDDIR}/.tested' to force test."
+		return
+	fi
+
+	trap "__abort_test" SIGINT SIGQUIT
+	__start_distcc
+
+	if [ -d "${S}" ]; then
+		cd "${S}"
+	else
+		cd "${WORKDIR}"
+	fi
+
+	if has test ${RESTRICT} ; then
+		einfo "Skipping make test/check due to ebuild restriction."
+		__vecho ">>> Test phase [disabled because of RESTRICT=test]: ${CATEGORY}/${PF}"
+
+	# If ${EBUILD_FORCE_TEST} == 1 and FEATURES came from ${T}/environment
+	# then it might not have FEATURES=test like it's supposed to here.
+	elif [[ ${EBUILD_FORCE_TEST} != 1 ]] && ! has test ${FEATURES} ; then
+		__vecho ">>> Test phase [not enabled]: ${CATEGORY}/${PF}"
+	else
+		local save_sp=${SANDBOX_PREDICT}
+		addpredict /
+		__ebuild_phase pre_src_test
+
+		__vecho ">>> Test phase: ${CATEGORY}/${PF}"
+		__ebuild_phase src_test
+		__vecho ">>> Completed testing ${CATEGORY}/${PF}"
+
+		>> "$PORTAGE_BUILDDIR/.tested" || \
+			die "Failed to create $PORTAGE_BUILDDIR/.tested"
+		__ebuild_phase post_src_test
+		SANDBOX_PREDICT=${save_sp}
+	fi
+
+	trap - SIGINT SIGQUIT
+}
+
+__dyn_install() {
+	[ -z "$PORTAGE_BUILDDIR" ] && die "${FUNCNAME}: PORTAGE_BUILDDIR is unset"
+	if has noauto $FEATURES ; then
+		rm -f "${PORTAGE_BUILDDIR}/.installed"
+	elif [[ -e $PORTAGE_BUILDDIR/.installed ]] ; then
+		__vecho ">>> It appears that '${PF}' is already installed; skipping."
+		__vecho ">>> Remove '${PORTAGE_BUILDDIR}/.installed' to force install."
+		return 0
+	fi
+	trap "__abort_install" SIGINT SIGQUIT
+	__start_distcc
+
+	__ebuild_phase pre_src_install
+
+	if ___eapi_has_prefix_variables; then
+		_x=${ED}
+	else
+		_x=${D}
+	fi
+	rm -rf "${D}"
+	mkdir -p "${_x}"
+	unset _x
+
+	if [[ -d $S ]] ; then
+		cd "${S}"
+	elif ___eapi_has_S_WORKDIR_fallback; then
+		cd "${WORKDIR}"
+	elif [[ -z ${A} ]] && ! __has_phase_defined_up_to install; then
+		cd "${WORKDIR}"
+	else
+		die "The source directory '${S}' doesn't exist"
+	fi
+
+	__vecho
+	__vecho ">>> Install ${PF} into ${D} category ${CATEGORY}"
+	#our custom version of libtool uses $S and $D to fix
+	#invalid paths in .la files
+	export S D
+
+	# Reset exeinto(), docinto(), insinto(), and into() state variables
+	# in case the user is running the install phase multiple times
+	# consecutively via the ebuild command.
+	export DESTTREE=/usr
+	export INSDESTTREE=""
+	export _E_EXEDESTTREE_=""
+	export _E_DOCDESTTREE_=""
+
+	__ebuild_phase src_install
+	>> "$PORTAGE_BUILDDIR/.installed" || \
+		die "Failed to create $PORTAGE_BUILDDIR/.installed"
+	__vecho ">>> Completed installing ${PF} into ${D}"
+	__vecho
+	__ebuild_phase post_src_install
+
+	cd "${PORTAGE_BUILDDIR}"/build-info
+	set -f
+	local f x
+	IFS=$' \t\n\r'
+	for f in CATEGORY DEFINED_PHASES FEATURES INHERITED IUSE \
+		PF PKGUSE SLOT KEYWORDS HOMEPAGE DESCRIPTION ; do
+		x=$(echo -n ${!f})
+		[[ -n $x ]] && echo "$x" > $f
+	done
+	if [[ $CATEGORY != virtual ]] ; then
+		for f in ASFLAGS CBUILD CC CFLAGS CHOST CTARGET CXX \
+			CXXFLAGS EXTRA_ECONF EXTRA_EINSTALL EXTRA_MAKE \
+			LDFLAGS LIBCFLAGS LIBCXXFLAGS QA_CONFIGURE_OPTIONS \
+			QA_DESKTOP_FILE QA_PREBUILT PROVIDES_EXCLUDE REQUIRES_EXCLUDE ; do
+			x=$(echo -n ${!f})
+			[[ -n $x ]] && echo "$x" > $f
+		done
+		# whitespace preserved
+		for f in QA_AM_MAINTAINER_MODE ; do
+			[[ -n ${!f} ]] && echo "${!f}" > $f
+		done
+	fi
+	echo "${USE}"       > USE
+	echo "${EAPI:-0}"   > EAPI
+
+	# Save EPREFIX, since it makes it easy to use chpathtool to
+	# adjust the content of a binary package so that it will
+	# work in a different EPREFIX from the one is was built for.
+	if ___eapi_has_prefix_variables && [[ -n ${EPREFIX} ]]; then
+		echo "${EPREFIX}" > EPREFIX
+	fi
+
+	set +f
+
+	# local variables can leak into the saved environment.
+	unset f
+
+	# Use safe cwd, avoiding unsafe import for bug #469338.
+	cd "${PORTAGE_PYM_PATH}"
+	__save_ebuild_env --exclude-init-phases | __filter_readonly_variables \
+		--filter-path --filter-sandbox --allow-extra-vars > \
+		"${PORTAGE_BUILDDIR}"/build-info/environment
+	assert "__save_ebuild_env failed"
+	cd "${PORTAGE_BUILDDIR}"/build-info || die
+
+	${PORTAGE_BZIP2_COMMAND} -f9 environment
+
+	cp "${EBUILD}" "${PF}.ebuild"
+	[ -n "${PORTAGE_REPO_NAME}" ]  && echo "${PORTAGE_REPO_NAME}" > repository
+	if has nostrip ${FEATURES} ${RESTRICT} || has strip ${RESTRICT}
+	then
+		>> DEBUGBUILD
+	fi
+	trap - SIGINT SIGQUIT
+}
+
+__dyn_help() {
+	echo
+	echo "Portage"
+	echo "Copyright 1999-2010 Gentoo Foundation"
+	echo
+	echo "How to use the ebuild command:"
+	echo
+	echo "The first argument to ebuild should be an existing .ebuild file."
+	echo
+	echo "One or more of the following options can then be specified.  If more"
+	echo "than one option is specified, each will be executed in order."
+	echo
+	echo "  help        : show this help screen"
+	echo "  pretend     : execute package specific pretend actions"
+	echo "  setup       : execute package specific setup actions"
+	echo "  fetch       : download source archive(s) and patches"
+	echo "  nofetch     : display special fetch instructions"
+	echo "  digest      : create a manifest file for the package"
+	echo "  manifest    : create a manifest file for the package"
+	echo "  unpack      : unpack sources (auto-dependencies if needed)"
+	echo "  prepare     : prepare sources (auto-dependencies if needed)"
+	echo "  configure   : configure sources (auto-fetch/unpack if needed)"
+	echo "  compile     : compile sources (auto-fetch/unpack/configure if needed)"
+	echo "  test        : test package (auto-fetch/unpack/configure/compile if needed)"
+	echo "  preinst     : execute pre-install instructions"
+	echo "  postinst    : execute post-install instructions"
+	echo "  install     : install the package to the temporary install directory"
+	echo "  qmerge      : merge image into live filesystem, recording files in db"
+	echo "  merge       : do fetch, unpack, compile, install and qmerge"
+	echo "  prerm       : execute pre-removal instructions"
+	echo "  postrm      : execute post-removal instructions"
+	echo "  unmerge     : remove package from live filesystem"
+	echo "  config      : execute package specific configuration actions"
+	echo "  package     : create a tarball package in ${PKGDIR}/All"
+	echo "  rpm         : build a RedHat RPM package"
+	echo "  clean       : clean up all source and temporary files"
+	echo
+	echo "The following settings will be used for the ebuild process:"
+	echo
+	echo "  package     : ${PF}"
+	echo "  slot        : ${SLOT}"
+	echo "  category    : ${CATEGORY}"
+	echo "  description : ${DESCRIPTION}"
+	echo "  system      : ${CHOST}"
+	echo "  c flags     : ${CFLAGS}"
+	echo "  c++ flags   : ${CXXFLAGS}"
+	echo "  make flags  : ${MAKEOPTS}"
+	echo -n "  build mode  : "
+	if has nostrip ${FEATURES} ${RESTRICT} || has strip ${RESTRICT} ;
+	then
+		echo "debug (large)"
+	else
+		echo "production (stripped)"
+	fi
+	echo "  merge to    : ${ROOT}"
+	echo
+	if [ -n "$USE" ]; then
+		echo "Additionally, support for the following optional features will be enabled:"
+		echo
+		echo "  ${USE}"
+	fi
+	echo
+}
+
+# @FUNCTION: __ebuild_arg_to_phase
+# @DESCRIPTION:
+# Translate a known ebuild(1) argument into the precise
+# name of it's corresponding ebuild phase.
+__ebuild_arg_to_phase() {
+	[ $# -ne 1 ] && die "expected exactly 1 arg, got $#: $*"
+	local arg=$1
+	local phase_func=""
+
+	case "$arg" in
+		pretend)
+			___eapi_has_pkg_pretend && \
+				phase_func=pkg_pretend
+			;;
+		setup)
+			phase_func=pkg_setup
+			;;
+		nofetch)
+			phase_func=pkg_nofetch
+			;;
+		unpack)
+			phase_func=src_unpack
+			;;
+		prepare)
+			___eapi_has_src_prepare && \
+				phase_func=src_prepare
+			;;
+		configure)
+			___eapi_has_src_configure && \
+				phase_func=src_configure
+			;;
+		compile)
+			phase_func=src_compile
+			;;
+		test)
+			phase_func=src_test
+			;;
+		install)
+			phase_func=src_install
+			;;
+		preinst)
+			phase_func=pkg_preinst
+			;;
+		postinst)
+			phase_func=pkg_postinst
+			;;
+		prerm)
+			phase_func=pkg_prerm
+			;;
+		postrm)
+			phase_func=pkg_postrm
+			;;
+	esac
+
+	[[ -z $phase_func ]] && return 1
+	echo "$phase_func"
+	return 0
+}
+
+__ebuild_phase_funcs() {
+	[ $# -ne 2 ] && die "expected exactly 2 args, got $#: $*"
+	local eapi=$1
+	local phase_func=$2
+	local all_phases="src_compile pkg_config src_configure pkg_info
+		src_install pkg_nofetch pkg_postinst pkg_postrm pkg_preinst
+		src_prepare pkg_prerm pkg_pretend pkg_setup src_test src_unpack"
+	local x
+
+	# First, set up the error handlers for default*
+	for x in ${all_phases} ; do
+		eval "default_${x}() {
+			die \"default_${x}() is not supported in EAPI='${eapi}' in phase ${phase_func}\"
+		}"
+	done
+
+	# We can just call the specific handler -- it will either error out
+	# on invalid phase or run it.
+	eval "default() {
+		default_${phase_func}
+	}"
+
+	case "$eapi" in
+		0|1) # EAPIs not supporting 'default'
+
+			for x in pkg_nofetch src_unpack src_test ; do
+				declare -F $x >/dev/null || \
+					eval "$x() { __eapi0_$x; }"
+			done
+
+			if ! declare -F src_compile >/dev/null ; then
+				case "$eapi" in
+					0)
+						src_compile() { __eapi0_src_compile; }
+						;;
+					*)
+						src_compile() { __eapi1_src_compile; }
+						;;
+				esac
+			fi
+			;;
+
+		*) # EAPIs supporting 'default'
+
+			# defaults starting with EAPI 0
+			[[ ${phase_func} == pkg_nofetch ]] && \
+				default_pkg_nofetch() { __eapi0_pkg_nofetch; }
+			[[ ${phase_func} == src_unpack ]] && \
+				default_src_unpack() { __eapi0_src_unpack; }
+			[[ ${phase_func} == src_test ]] && \
+				default_src_test() { __eapi0_src_test; }
+
+			# defaults starting with EAPI 2
+			[[ ${phase_func} == src_prepare ]] && \
+				default_src_prepare() { __eapi2_src_prepare; }
+			[[ ${phase_func} == src_configure ]] && \
+				default_src_configure() { __eapi2_src_configure; }
+			[[ ${phase_func} == src_compile ]] && \
+				default_src_compile() { __eapi2_src_compile; }
+
+			# bind supported phases to the defaults
+			declare -F pkg_nofetch >/dev/null || \
+				pkg_nofetch() { default; }
+			declare -F src_unpack >/dev/null || \
+				src_unpack() { default; }
+			declare -F src_prepare >/dev/null || \
+				src_prepare() { default; }
+			declare -F src_configure >/dev/null || \
+				src_configure() { default; }
+			declare -F src_compile >/dev/null || \
+				src_compile() { default; }
+			declare -F src_test >/dev/null || \
+				src_test() { default; }
+
+			# defaults starting with EAPI 4
+			if ! has ${eapi} 2 3; then
+				[[ ${phase_func} == src_install ]] && \
+					default_src_install() { __eapi4_src_install; }
+
+				declare -F src_install >/dev/null || \
+					src_install() { default; }
+			fi
+
+			# defaults starting with EAPI 6
+			if ! has ${eapi} 2 3 4 4-python 4-slot-abi 5 5-progress 5-hdepend; then
+				[[ ${phase_func} == src_prepare ]] && \
+					default_src_prepare() { __eapi6_src_prepare; }
+				[[ ${phase_func} == src_install ]] && \
+					default_src_install() { __eapi6_src_install; }
+
+				declare -F src_prepare >/dev/null || \
+					src_prepare() { default; }
+			fi
+			;;
+	esac
+}
+
+__ebuild_main() {
+
+	# Subshell/helper die support (must export for the die helper).
+	# Since this function is typically executed in a subshell,
+	# setup EBUILD_MASTER_PID to refer to the current $BASHPID,
+	# which seems to give the best results when further
+	# nested subshells call die.
+	export EBUILD_MASTER_PID=${BASHPID:-$(__bashpid)}
+	trap 'exit 1' SIGTERM
+
+	#a reasonable default for $S
+	[[ -z ${S} ]] && export S=${WORKDIR}/${P}
+
+	if [[ -s $SANDBOX_LOG ]] ; then
+		# We use SANDBOX_LOG to check for sandbox violations,
+		# so we ensure that there can't be a stale log to
+		# interfere with our logic.
+		local x=
+		if [[ -n SANDBOX_ON ]] ; then
+			x=$SANDBOX_ON
+			export SANDBOX_ON=0
+		fi
+
+		rm -f "$SANDBOX_LOG" || \
+			die "failed to remove stale sandbox log: '$SANDBOX_LOG'"
+
+		if [[ -n $x ]] ; then
+			export SANDBOX_ON=$x
+		fi
+		unset x
+	fi
+
+	# Force configure scripts that automatically detect ccache to
+	# respect FEATURES="-ccache".
+	has ccache $FEATURES || export CCACHE_DISABLE=1
+
+	local phase_func=$(__ebuild_arg_to_phase "$EBUILD_PHASE")
+	[[ -n $phase_func ]] && __ebuild_phase_funcs "$EAPI" "$phase_func"
+	unset phase_func
+
+	__source_all_bashrcs
+
+	case ${1} in
+	nofetch)
+		__ebuild_phase_with_hooks pkg_nofetch
+		;;
+	prerm|postrm|preinst|postinst|config|info)
+		if has "${1}" config info && \
+			! declare -F "pkg_${1}" >/dev/null ; then
+			ewarn  "pkg_${1}() is not defined: '${EBUILD##*/}'"
+		fi
+		export SANDBOX_ON="0"
+		if [ "${PORTAGE_DEBUG}" != "1" ] || [ "${-/x/}" != "$-" ]; then
+			__ebuild_phase_with_hooks pkg_${1}
+		else
+			set -x
+			__ebuild_phase_with_hooks pkg_${1}
+			set +x
+		fi
+		if [[ -n $PORTAGE_UPDATE_ENV ]] ; then
+			# Update environment.bz2 in case installation phases
+			# need to pass some variables to uninstallation phases.
+			# Use safe cwd, avoiding unsafe import for bug #469338.
+			cd "${PORTAGE_PYM_PATH}"
+			__save_ebuild_env --exclude-init-phases | \
+				__filter_readonly_variables --filter-path \
+				--filter-sandbox --allow-extra-vars \
+				| ${PORTAGE_BZIP2_COMMAND} -c -f9 > "$PORTAGE_UPDATE_ENV"
+			assert "__save_ebuild_env failed"
+		fi
+		;;
+	unpack|prepare|configure|compile|test|clean|install)
+		if [[ ${SANDBOX_DISABLED:-0} = 0 ]] ; then
+			export SANDBOX_ON="1"
+		else
+			export SANDBOX_ON="0"
+		fi
+
+		case "${1}" in
+		configure|compile)
+
+			local x
+			for x in ASFLAGS CCACHE_DIR CCACHE_SIZE \
+				CFLAGS CXXFLAGS LDFLAGS LIBCFLAGS LIBCXXFLAGS ; do
+				[[ ${!x+set} = set ]] && export $x
+			done
+			unset x
+
+			has distcc $FEATURES && [[ -n $DISTCC_DIR ]] && \
+				[[ ${SANDBOX_WRITE/$DISTCC_DIR} = $SANDBOX_WRITE ]] && \
+				addwrite "$DISTCC_DIR"
+
+			x=LIBDIR_$ABI
+			[ -z "$PKG_CONFIG_PATH" -a -n "$ABI" -a -n "${!x}" ] && \
+				export PKG_CONFIG_PATH=${EPREFIX}/usr/${!x}/pkgconfig
+
+			if has noauto $FEATURES && \
+				[[ ! -f $PORTAGE_BUILDDIR/.unpacked ]] ; then
+				echo
+				echo "!!! We apparently haven't unpacked..." \
+					"This is probably not what you"
+				echo "!!! want to be doing... You are using" \
+					"FEATURES=noauto so I'll assume"
+				echo "!!! that you know what you are doing..." \
+					"You have 5 seconds to abort..."
+				echo
+
+				local x
+				for x in 1 2 3 4 5 6 7 8; do
+					LC_ALL=C sleep 0.25
+				done
+
+				sleep 3
+			fi
+
+			cd "$PORTAGE_BUILDDIR"
+			if [ ! -d build-info ] ; then
+				mkdir build-info
+				cp "$EBUILD" "build-info/$PF.ebuild"
+			fi
+
+			#our custom version of libtool uses $S and $D to fix
+			#invalid paths in .la files
+			export S D
+
+			;;
+		esac
+
+		if [ "${PORTAGE_DEBUG}" != "1" ] || [ "${-/x/}" != "$-" ]; then
+			__dyn_${1}
+		else
+			set -x
+			__dyn_${1}
+			set +x
+		fi
+		export SANDBOX_ON="0"
+		;;
+	help|pretend|setup)
+		#pkg_setup needs to be out of the sandbox for tmp file creation;
+		#for example, awking and piping a file in /tmp requires a temp file to be created
+		#in /etc.  If pkg_setup is in the sandbox, both our lilo and apache ebuilds break.
+		export SANDBOX_ON="0"
+		if [ "${PORTAGE_DEBUG}" != "1" ] || [ "${-/x/}" != "$-" ]; then
+			__dyn_${1}
+		else
+			set -x
+			__dyn_${1}
+			set +x
+		fi
+		;;
+	_internal_test)
+		;;
+	*)
+		export SANDBOX_ON="1"
+		echo "Unrecognized arg '${1}'"
+		echo
+		__dyn_help
+		exit 1
+		;;
+	esac
+
+	# Save the env only for relevant phases.
+	if ! has "${1}" clean help info nofetch ; then
+		umask 002
+		# Use safe cwd, avoiding unsafe import for bug #469338.
+		cd "${PORTAGE_PYM_PATH}"
+		__save_ebuild_env | __filter_readonly_variables \
+			--filter-features > "$T/environment"
+		assert "__save_ebuild_env failed"
+		chgrp "${PORTAGE_GRPNAME:-portage}" "$T/environment"
+		chmod g+w "$T/environment"
+	fi
+	[[ -n $PORTAGE_EBUILD_EXIT_FILE ]] && > "$PORTAGE_EBUILD_EXIT_FILE"
+	if [[ -n $PORTAGE_IPC_DAEMON ]] ; then
+		[[ ! -s $SANDBOX_LOG ]]
+		"$PORTAGE_BIN_PATH"/ebuild-ipc exit $?
+	fi
+}

--- a/share/phase-helpers.sh
+++ b/share/phase-helpers.sh
@@ -1,0 +1,1246 @@
+#!/bin/bash
+# Copyright 1999-2013 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+export DESTTREE=/usr
+export INSDESTTREE=""
+export _E_EXEDESTTREE_=""
+export _E_DOCDESTTREE_=""
+export INSOPTIONS="-m0644"
+export EXEOPTIONS="-m0755"
+export LIBOPTIONS="-m0644"
+export DIROPTIONS="-m0755"
+export MOPREFIX=${PN}
+# Do not compress files which are smaller than this (in bytes). #169260
+export PORTAGE_DOCOMPRESS_SIZE_LIMIT="128"
+declare -a PORTAGE_DOCOMPRESS=( /usr/share/{doc,info,man} )
+declare -a PORTAGE_DOCOMPRESS_SKIP=( /usr/share/doc/${PF}/html )
+
+into() {
+	if [ "$1" == "/" ]; then
+		export DESTTREE=""
+	else
+		export DESTTREE=$1
+		if ! ___eapi_has_prefix_variables; then
+			local ED=${D}
+		fi
+		if [ ! -d "${ED}${DESTTREE}" ]; then
+			install -d "${ED}${DESTTREE}"
+			local ret=$?
+			if [[ $ret -ne 0 ]] ; then
+				__helpers_die "${FUNCNAME[0]} failed"
+				return $ret
+			fi
+		fi
+	fi
+}
+
+insinto() {
+	if [ "$1" == "/" ]; then
+		export INSDESTTREE=""
+	else
+		export INSDESTTREE=$1
+		if ! ___eapi_has_prefix_variables; then
+			local ED=${D}
+		fi
+		if [ ! -d "${ED}${INSDESTTREE}" ]; then
+			install -d "${ED}${INSDESTTREE}"
+			local ret=$?
+			if [[ $ret -ne 0 ]] ; then
+				__helpers_die "${FUNCNAME[0]} failed"
+				return $ret
+			fi
+		fi
+	fi
+}
+
+exeinto() {
+	if [ "$1" == "/" ]; then
+		export _E_EXEDESTTREE_=""
+	else
+		export _E_EXEDESTTREE_="$1"
+		if ! ___eapi_has_prefix_variables; then
+			local ED=${D}
+		fi
+		if [ ! -d "${ED}${_E_EXEDESTTREE_}" ]; then
+			install -d "${ED}${_E_EXEDESTTREE_}"
+			local ret=$?
+			if [[ $ret -ne 0 ]] ; then
+				__helpers_die "${FUNCNAME[0]} failed"
+				return $ret
+			fi
+		fi
+	fi
+}
+
+docinto() {
+	if [ "$1" == "/" ]; then
+		export _E_DOCDESTTREE_=""
+	else
+		export _E_DOCDESTTREE_="$1"
+		if ! ___eapi_has_prefix_variables; then
+			local ED=${D}
+		fi
+		if [ ! -d "${ED}usr/share/doc/${PF}/${_E_DOCDESTTREE_}" ]; then
+			install -d "${ED}usr/share/doc/${PF}/${_E_DOCDESTTREE_}"
+			local ret=$?
+			if [[ $ret -ne 0 ]] ; then
+				__helpers_die "${FUNCNAME[0]} failed"
+				return $ret
+			fi
+		fi
+	fi
+}
+
+insopts() {
+	export INSOPTIONS="$@"
+
+	# `install` should never be called with '-s' ...
+	has -s ${INSOPTIONS} && die "Never call insopts() with -s"
+}
+
+diropts() {
+	export DIROPTIONS="$@"
+}
+
+exeopts() {
+	export EXEOPTIONS="$@"
+
+	# `install` should never be called with '-s' ...
+	has -s ${EXEOPTIONS} && die "Never call exeopts() with -s"
+}
+
+libopts() {
+	export LIBOPTIONS="$@"
+
+	# `install` should never be called with '-s' ...
+	has -s ${LIBOPTIONS} && die "Never call libopts() with -s"
+}
+
+docompress() {
+	___eapi_has_docompress || die "'docompress' not supported in this EAPI"
+
+	local f g
+	if [[ $1 = "-x" ]]; then
+		shift
+		for f; do
+			f=$(__strip_duplicate_slashes "${f}"); f=${f%/}
+			[[ ${f:0:1} = / ]] || f="/${f}"
+			for g in "${PORTAGE_DOCOMPRESS_SKIP[@]}"; do
+				[[ ${f} = "${g}" ]] && continue 2
+			done
+			PORTAGE_DOCOMPRESS_SKIP[${#PORTAGE_DOCOMPRESS_SKIP[@]}]=${f}
+		done
+	else
+		for f; do
+			f=$(__strip_duplicate_slashes "${f}"); f=${f%/}
+			[[ ${f:0:1} = / ]] || f="/${f}"
+			for g in "${PORTAGE_DOCOMPRESS[@]}"; do
+				[[ ${f} = "${g}" ]] && continue 2
+			done
+			PORTAGE_DOCOMPRESS[${#PORTAGE_DOCOMPRESS[@]}]=${f}
+		done
+	fi
+}
+
+useq() {
+	has $EBUILD_PHASE prerm postrm || eqawarn \
+		"QA Notice: The 'useq' function is deprecated (replaced by 'use')"
+	use ${1}
+}
+
+usev() {
+	if use ${1}; then
+		echo "${1#!}"
+		return 0
+	fi
+	return 1
+}
+
+if ___eapi_has_usex; then
+	usex() {
+		if use "$1"; then
+			echo "${2-yes}$4"
+		else
+			echo "${3-no}$5"
+		fi
+		return 0
+	}
+fi
+
+use() {
+	local u=$1
+	local found=0
+
+	# if we got something like '!flag', then invert the return value
+	if [[ ${u:0:1} == "!" ]] ; then
+		u=${u:1}
+		found=1
+	fi
+
+	if [[ $EBUILD_PHASE = depend ]] ; then
+		# TODO: Add a registration interface for eclasses to register
+		# any number of phase hooks, so that global scope eclass
+		# initialization can by migrated to phase hooks in new EAPIs.
+		# Example: add_phase_hook before pkg_setup $ECLASS_pre_pkg_setup
+		#if [[ -n $EAPI ]] && ! has "$EAPI" 0 1 2 3 ; then
+		#	die "use() called during invalid phase: $EBUILD_PHASE"
+		#fi
+		true
+
+	# Make sure we have this USE flag in IUSE, but exempt binary
+	# packages for API consumers like Entropy which do not require
+	# a full profile with IUSE_IMPLICIT and stuff (see bug #456830).
+	elif [[ -n $PORTAGE_IUSE && -n $EBUILD_PHASE &&
+		-n $PORTAGE_INTERNAL_CALLER ]] ; then
+		if [[ ! $u =~ $PORTAGE_IUSE ]] ; then
+			if [[ ! ${EAPI} =~ ^(0|1|2|3|4|4-python|4-slot-abi)$ ]] ; then
+				# This is only strict starting with EAPI 5, since implicit IUSE
+				# is not well defined for earlier EAPIs (see bug #449708).
+				die "USE Flag '${u}' not in IUSE for ${CATEGORY}/${PF}"
+			fi
+			eqawarn "QA Notice: USE Flag '${u}' not" \
+				"in IUSE for ${CATEGORY}/${PF}"
+		fi
+	fi
+
+	local IFS=$' \t\n' prev_shopts=$- ret
+	set -f
+	if has ${u} ${USE} ; then
+		ret=${found}
+	else
+		ret=$((!found))
+	fi
+	[[ ${prev_shopts} == *f* ]] || set +f
+	return ${ret}
+}
+
+use_with() {
+	if [ -z "$1" ]; then
+		echo "!!! use_with() called without a parameter." >&2
+		echo "!!! use_with <USEFLAG> [<flagname> [value]]" >&2
+		return 1
+	fi
+
+	if ___eapi_use_enable_and_use_with_support_empty_third_argument; then
+		local UW_SUFFIX=${3+=$3}
+	else
+		local UW_SUFFIX=${3:+=$3}
+	fi
+	local UWORD=${2:-$1}
+
+	if use $1; then
+		echo "--with-${UWORD}${UW_SUFFIX}"
+	else
+		echo "--without-${UWORD}"
+	fi
+	return 0
+}
+
+use_enable() {
+	if [ -z "$1" ]; then
+		echo "!!! use_enable() called without a parameter." >&2
+		echo "!!! use_enable <USEFLAG> [<flagname> [value]]" >&2
+		return 1
+	fi
+
+	if ___eapi_use_enable_and_use_with_support_empty_third_argument; then
+		local UE_SUFFIX=${3+=$3}
+	else
+		local UE_SUFFIX=${3:+=$3}
+	fi
+	local UWORD=${2:-$1}
+
+	if use $1; then
+		echo "--enable-${UWORD}${UE_SUFFIX}"
+	else
+		echo "--disable-${UWORD}"
+	fi
+	return 0
+}
+
+unpack() {
+	local srcdir
+	local x
+	local y y_insensitive
+	local suffix suffix_insensitive
+	local myfail
+	local eapi=${EAPI:-0}
+	[ -z "$*" ] && die "Nothing passed to the 'unpack' command"
+
+	for x in "$@"; do
+		__vecho ">>> Unpacking ${x} to ${PWD}"
+		suffix=${x##*.}
+		suffix_insensitive=$(LC_ALL=C tr "[:upper:]" "[:lower:]" <<< "${suffix}")
+		y=${x%.*}
+		y=${y##*.}
+		y_insensitive=$(LC_ALL=C tr "[:upper:]" "[:lower:]" <<< "${y}")
+
+		# wrt PMS 11.3.3.13 Misc Commands
+		if [[ ${x} != */* ]]; then
+			# filename without path of any kind
+			srcdir=${DISTDIR}/
+		elif [[ ${x} == ./* ]]; then
+			# relative path starting with './'
+			srcdir=
+		else
+			# non-'./' filename with path of some kind
+			if ___eapi_unpack_supports_absolute_paths; then
+				# EAPI 6 allows absolute and deep relative paths
+				srcdir=
+
+				if [[ ${x} == ${DISTDIR%/}/* ]]; then
+					eqawarn "QA Notice: unpack called with redundant \${DISTDIR} in path"
+				fi
+			elif [[ ${x} == ${DISTDIR%/}/* ]]; then
+				die "Arguments to unpack() cannot begin with \${DISTDIR} in EAPI ${EAPI}"
+			elif [[ ${x} == /* ]] ; then
+				die "Arguments to unpack() cannot be absolute in EAPI ${EAPI}"
+			else
+				die "Relative paths to unpack() must be prefixed with './' in EAPI ${EAPI}"
+			fi
+		fi
+		if [[ ! -s ${srcdir}${x} ]]; then
+			__helpers_die "unpack: ${x} does not exist"
+			return 1
+		fi
+
+		__unpack_tar() {
+			if [[ ${y_insensitive} == tar ]] ; then
+				if ___eapi_unpack_is_case_sensitive && \
+					[[ tar != ${y} ]] ; then
+					eqawarn "QA Notice: unpack called with" \
+						"secondary suffix '${y}' which is unofficially" \
+						"supported with EAPI '${EAPI}'. Instead use 'tar'."
+				fi
+				$1 -c -- "$srcdir$x" | tar xof -
+				__assert_sigpipe_ok "$myfail" || return 1
+			else
+				local cwd_dest=${x##*/}
+				cwd_dest=${cwd_dest%.*}
+				if ! $1 -c -- "${srcdir}${x}" > "${cwd_dest}"; then
+					__helpers_die "$myfail"
+					return 1
+				fi
+			fi
+		}
+
+		myfail="unpack: failure unpacking ${x}"
+		case "${suffix_insensitive}" in
+			tar)
+				if ___eapi_unpack_is_case_sensitive && \
+					[[ tar != ${suffix} ]] ; then
+					eqawarn "QA Notice: unpack called with" \
+						"suffix '${suffix}' which is unofficially supported" \
+						"with EAPI '${EAPI}'. Instead use 'tar'."
+				fi
+				if ! tar xof "$srcdir$x"; then
+					__helpers_die "$myfail"
+					return 1
+				fi
+				;;
+			tgz)
+				if ___eapi_unpack_is_case_sensitive && \
+					[[ tgz != ${suffix} ]] ; then
+					eqawarn "QA Notice: unpack called with" \
+						"suffix '${suffix}' which is unofficially supported" \
+						"with EAPI '${EAPI}'. Instead use 'tgz'."
+				fi
+				if ! tar xozf "$srcdir$x"; then
+					__helpers_die "$myfail"
+					return 1
+				fi
+				;;
+			tbz|tbz2)
+				if ___eapi_unpack_is_case_sensitive && \
+					[[ " tbz tbz2 " != *" ${suffix} "* ]] ; then
+					eqawarn "QA Notice: unpack called with" \
+						"suffix '${suffix}' which is unofficially supported" \
+						"with EAPI '${EAPI}'. Instead use 'tbz' or 'tbz2'."
+				fi
+				${PORTAGE_BUNZIP2_COMMAND:-${PORTAGE_BZIP2_COMMAND} -d} -c -- "$srcdir$x" | tar xof -
+				__assert_sigpipe_ok "$myfail" || return 1
+				;;
+			zip|jar)
+				if ___eapi_unpack_is_case_sensitive && \
+					[[ " ZIP zip jar " != *" ${suffix} "* ]] ; then
+					eqawarn "QA Notice: unpack called with" \
+						"suffix '${suffix}' which is unofficially supported" \
+						"with EAPI '${EAPI}'." \
+						"Instead use 'ZIP', 'zip', or 'jar'."
+				fi
+				# unzip will interactively prompt under some error conditions,
+				# as reported in bug #336285
+				if ! unzip -qo "${srcdir}${x}"; then
+					__helpers_die "$myfail"
+					return 1
+				fi < <(set +x ; while true ; do echo n || break ; done)
+				;;
+			gz|z)
+				if ___eapi_unpack_is_case_sensitive && \
+					[[ " gz z Z " != *" ${suffix} "* ]] ; then
+					eqawarn "QA Notice: unpack called with" \
+						"suffix '${suffix}' which is unofficially supported" \
+						"with EAPI '${EAPI}'. Instead use 'gz', 'z', or 'Z'."
+				fi
+				__unpack_tar "gzip -d" || return 1
+				;;
+			bz2|bz)
+				if ___eapi_unpack_is_case_sensitive && \
+					[[ " bz bz2 " != *" ${suffix} "* ]] ; then
+					eqawarn "QA Notice: unpack called with" \
+						"suffix '${suffix}' which is unofficially supported" \
+						"with EAPI '${EAPI}'. Instead use 'bz' or 'bz2'."
+				fi
+				__unpack_tar "${PORTAGE_BUNZIP2_COMMAND:-${PORTAGE_BZIP2_COMMAND} -d}" \
+					|| return 1
+				;;
+			7z)
+				local my_output
+				my_output="$(7z x -y "${srcdir}${x}")"
+				if [ $? -ne 0 ]; then
+					echo "${my_output}" >&2
+					die "$myfail"
+				fi
+				;;
+			rar)
+				if ___eapi_unpack_is_case_sensitive && \
+					[[ " rar RAR " != *" ${suffix} "* ]] ; then
+					eqawarn "QA Notice: unpack called with" \
+						"suffix '${suffix}' which is unofficially supported" \
+						"with EAPI '${EAPI}'. Instead use 'rar' or 'RAR'."
+				fi
+				if ! unrar x -idq -o+ "${srcdir}${x}"; then
+					__helpers_die "$myfail"
+					return 1
+				fi
+				;;
+			lha|lzh)
+				if ___eapi_unpack_is_case_sensitive && \
+					[[ " LHA LHa lha lzh " != *" ${suffix} "* ]] ; then
+					eqawarn "QA Notice: unpack called with" \
+						"suffix '${suffix}' which is unofficially supported" \
+						"with EAPI '${EAPI}'." \
+						"Instead use 'LHA', 'LHa', 'lha', or 'lzh'."
+				fi
+				if ! lha xfq "${srcdir}${x}"; then
+					__helpers_die "$myfail"
+					return 1
+				fi
+				;;
+			a)
+				if ___eapi_unpack_is_case_sensitive && \
+					[[ " a " != *" ${suffix} "* ]] ; then
+					eqawarn "QA Notice: unpack called with" \
+						"suffix '${suffix}' which is unofficially supported" \
+						"with EAPI '${EAPI}'. Instead use 'a'."
+				fi
+				if ! ar x "${srcdir}${x}"; then
+					__helpers_die "$myfail"
+					return 1
+				fi
+				;;
+			deb)
+				if ___eapi_unpack_is_case_sensitive && \
+					[[ " deb " != *" ${suffix} "* ]] ; then
+					eqawarn "QA Notice: unpack called with" \
+						"suffix '${suffix}' which is unofficially supported" \
+						"with EAPI '${EAPI}'. Instead use 'deb'."
+				fi
+				# Unpacking .deb archives can not always be done with
+				# `ar`.  For instance on AIX this doesn't work out.
+				# If `ar` is not the GNU binutils version and we have
+				# `deb2targz` installed, prefer it over `ar` for that
+				# reason.  We just make sure on AIX `deb2targz` is
+				# installed.
+				if [[ $(ar --version 2>/dev/null) != "GNU ar"* ]] && \
+					type -P deb2targz > /dev/null; then
+					y=${x##*/}
+					local created_symlink=0
+					if [ ! "$srcdir$x" -ef "$y" ] ; then
+						# deb2targz always extracts into the same directory as
+						# the source file, so create a symlink in the current
+						# working directory if necessary.
+						if ! ln -sf "$srcdir$x" "$y"; then
+							__helpers_die "$myfail"
+							return 1
+						fi
+						created_symlink=1
+					fi
+					if ! deb2targz "$y"; then
+						__helpers_die "$myfail"
+						return 1
+					fi
+					if [ $created_symlink = 1 ] ; then
+						# Clean up the symlink so the ebuild
+						# doesn't inadvertently install it.
+						rm -f "$y"
+					fi
+					if ! mv -f "${y%.deb}".tar.gz data.tar.gz; then
+						if ! mv -f "${y%.deb}".tar.xz data.tar.xz; then
+							__helpers_die "$myfail"
+							return 1
+						fi
+					fi
+				else
+					if ! ar x "$srcdir$x"; then
+						__helpers_die "$myfail"
+						return 1
+					fi
+				fi
+				;;
+			lzma)
+				if ___eapi_unpack_is_case_sensitive && \
+					[[ " lzma " != *" ${suffix} "* ]] ; then
+					eqawarn "QA Notice: unpack called with" \
+						"suffix '${suffix}' which is unofficially supported" \
+						"with EAPI '${EAPI}'. Instead use 'lzma'."
+				fi
+				__unpack_tar "lzma -d" || return 1
+				;;
+			xz)
+				if ___eapi_unpack_is_case_sensitive && \
+					[[ " xz " != *" ${suffix} "* ]] ; then
+					eqawarn "QA Notice: unpack called with" \
+						"suffix '${suffix}' which is unofficially supported" \
+						"with EAPI '${EAPI}'. Instead use 'xz'."
+				fi
+				if ___eapi_unpack_supports_xz; then
+					__unpack_tar "xz -d" || return 1
+				else
+					__vecho "unpack ${x}: file format not recognized. Ignoring."
+				fi
+				;;
+			txz)
+				if ___eapi_unpack_is_case_sensitive && \
+					[[ " txz " != *" ${suffix} "* ]] ; then
+					eqawarn "QA Notice: unpack called with" \
+						"suffix '${suffix}' which is unofficially supported" \
+						"with EAPI '${EAPI}'. Instead use 'txz'."
+				fi
+				if ___eapi_supports_txz; then
+					__unpack_tar "xz -d" || return 1
+				else
+					__vecho "unpack ${x}: file format not recognized. Ignoring."
+				fi
+				;;
+			*)
+				__vecho "unpack ${x}: file format not recognized. Ignoring."
+				;;
+		esac
+	done
+	# Do not chmod '.' since it's probably ${WORKDIR} and PORTAGE_WORKDIR_MODE
+	# should be preserved.
+	find . -mindepth 1 -maxdepth 1 ! -type l -print0 | \
+		${XARGS} -0 chmod -fR a+rX,u+w,g-w,o-w
+}
+
+econf() {
+	local x
+	local pid=${BASHPID:-$(__bashpid)}
+
+	if ! ___eapi_has_prefix_variables; then
+		local EPREFIX=
+	fi
+
+	__hasg() {
+		local x s=$1
+		shift
+		for x ; do [[ ${x} == ${s} ]] && echo "${x}" && return 0 ; done
+		return 1
+	}
+
+	__hasgq() { __hasg "$@" >/dev/null ; }
+
+	local phase_func=$(__ebuild_arg_to_phase "$EBUILD_PHASE")
+	if [[ -n $phase_func ]] ; then
+		if ! ___eapi_has_src_configure; then
+			[[ $phase_func != src_compile ]] && \
+				eqawarn "QA Notice: econf called in" \
+					"$phase_func instead of src_compile"
+		else
+			[[ $phase_func != src_configure ]] && \
+				eqawarn "QA Notice: econf called in" \
+					"$phase_func instead of src_configure"
+		fi
+	fi
+
+	: ${ECONF_SOURCE:=.}
+	if [ -x "${ECONF_SOURCE}/configure" ]; then
+		if [[ -n $CONFIG_SHELL && \
+			"$(head -n1 "$ECONF_SOURCE/configure")" =~ ^'#!'[[:space:]]*/bin/sh([[:space:]]|$) ]] ; then
+			# preserve timestamp, see bug #440304
+			touch -r "${ECONF_SOURCE}/configure" "${ECONF_SOURCE}/configure._portage_tmp_.${pid}" || die
+			sed -i \
+				-e "1s:^#![[:space:]]*/bin/sh:#!$CONFIG_SHELL:" \
+				"${ECONF_SOURCE}/configure" \
+				|| die "Substition of shebang in '${ECONF_SOURCE}/configure' failed"
+			touch -r "${ECONF_SOURCE}/configure._portage_tmp_.${pid}" "${ECONF_SOURCE}/configure" || die
+			rm -f "${ECONF_SOURCE}/configure._portage_tmp_.${pid}"
+		fi
+		if [ -e "${EPREFIX}"/usr/share/gnuconfig/ ]; then
+			find "${WORKDIR}" -type f '(' \
+			-name config.guess -o -name config.sub ')' -print0 | \
+			while read -r -d $'\0' x ; do
+				__vecho " * econf: updating ${x/${WORKDIR}\/} with ${EPREFIX}/usr/share/gnuconfig/${x##*/}"
+				# Make sure we do this atomically incase we're run in parallel. #487478
+				cp -f "${EPREFIX}"/usr/share/gnuconfig/"${x##*/}" "${x}.${pid}"
+				mv -f "${x}.${pid}" "${x}"
+			done
+		fi
+
+		local conf_args=()
+		if ___eapi_econf_passes_--disable-dependency-tracking || ___eapi_econf_passes_--disable-silent-rules || ___eapi_econf_passes_--docdir_and_--htmldir; then
+			local conf_help=$("${ECONF_SOURCE}/configure" --help 2>/dev/null)
+
+			if ___eapi_econf_passes_--disable-dependency-tracking; then
+				if [[ ${conf_help} == *--disable-dependency-tracking* ]]; then
+					conf_args+=( --disable-dependency-tracking )
+				fi
+			fi
+
+			if ___eapi_econf_passes_--disable-silent-rules; then
+				if [[ ${conf_help} == *--disable-silent-rules* ]]; then
+					conf_args+=( --disable-silent-rules )
+				fi
+			fi
+
+			if ___eapi_econf_passes_--docdir_and_--htmldir; then
+				if [[ ${conf_help} == *--docdir* ]]; then
+					conf_args+=( --docdir="${EPREFIX}"/usr/share/doc/${PF} )
+				fi
+
+				if [[ ${conf_help} == *--htmldir* ]]; then
+					conf_args+=( --htmldir="${EPREFIX}"/usr/share/doc/${PF}/html )
+				fi
+			fi
+		fi
+
+		# if the profile defines a location to install libs to aside from default, pass it on.
+		# if the ebuild passes in --libdir, they're responsible for the conf_libdir fun.
+		local CONF_LIBDIR LIBDIR_VAR="LIBDIR_${ABI}"
+		if [[ -n ${ABI} && -n ${!LIBDIR_VAR} ]] ; then
+			CONF_LIBDIR=${!LIBDIR_VAR}
+		fi
+		if [[ -n ${CONF_LIBDIR} ]] && ! __hasgq --libdir=\* "$@" ; then
+			export CONF_PREFIX=$(__hasg --exec-prefix=\* "$@")
+			[[ -z ${CONF_PREFIX} ]] && CONF_PREFIX=$(__hasg --prefix=\* "$@")
+			: ${CONF_PREFIX:=${EPREFIX}/usr}
+			CONF_PREFIX=${CONF_PREFIX#*=}
+			[[ ${CONF_PREFIX} != /* ]] && CONF_PREFIX="/${CONF_PREFIX}"
+			[[ ${CONF_LIBDIR} != /* ]] && CONF_LIBDIR="/${CONF_LIBDIR}"
+			conf_args+=(
+				--libdir="$(__strip_duplicate_slashes "${CONF_PREFIX}${CONF_LIBDIR}")"
+			)
+		fi
+
+		# Handle arguments containing quoted whitespace (see bug #457136).
+		eval "local -a EXTRA_ECONF=(${EXTRA_ECONF})"
+
+		set -- \
+			--prefix="${EPREFIX}"/usr \
+			${CBUILD:+--build=${CBUILD}} \
+			--host=${CHOST} \
+			${CTARGET:+--target=${CTARGET}} \
+			--mandir="${EPREFIX}"/usr/share/man \
+			--infodir="${EPREFIX}"/usr/share/info \
+			--datadir="${EPREFIX}"/usr/share \
+			--sysconfdir="${EPREFIX}"/etc \
+			--localstatedir="${EPREFIX}"/var/lib \
+			"${conf_args[@]}" \
+			"$@" \
+			"${EXTRA_ECONF[@]}"
+		__vecho "${ECONF_SOURCE}/configure" "$@"
+
+		if ! "${ECONF_SOURCE}/configure" "$@" ; then
+
+			if [ -s config.log ]; then
+				echo
+				echo "!!! Please attach the following file when seeking support:"
+				echo "!!! ${PWD}/config.log"
+			fi
+			__helpers_die "econf failed"
+			return 1
+		fi
+	elif [ -f "${ECONF_SOURCE}/configure" ]; then
+		die "configure is not executable"
+	else
+		die "no configure script found"
+	fi
+}
+
+einstall() {
+	if ! ___eapi_has_einstall; then
+		die "'${FUNCNAME}' has been banned for EAPI '$EAPI'"
+		exit 1
+	fi
+
+	# CONF_PREFIX is only set if they didn't pass in libdir above.
+	local LOCAL_EXTRA_EINSTALL="${EXTRA_EINSTALL}"
+	if ! ___eapi_has_prefix_variables; then
+		local ED=${D}
+	fi
+	LIBDIR_VAR="LIBDIR_${ABI}"
+	if [ -n "${ABI}" -a -n "${!LIBDIR_VAR}" ]; then
+		CONF_LIBDIR="${!LIBDIR_VAR}"
+	fi
+	unset LIBDIR_VAR
+	if [ -n "${CONF_LIBDIR}" ] && [ "${CONF_PREFIX:+set}" = set ]; then
+		EI_DESTLIBDIR="${D}/${CONF_PREFIX}/${CONF_LIBDIR}"
+		EI_DESTLIBDIR="$(__strip_duplicate_slashes "${EI_DESTLIBDIR}")"
+		LOCAL_EXTRA_EINSTALL="libdir=${EI_DESTLIBDIR} ${LOCAL_EXTRA_EINSTALL}"
+		unset EI_DESTLIBDIR
+	fi
+
+	if [ -f ./[mM]akefile -o -f ./GNUmakefile ] ; then
+		if [ "${PORTAGE_DEBUG}" == "1" ]; then
+			${MAKE:-make} -n prefix="${ED}usr" \
+				datadir="${ED}usr/share" \
+				infodir="${ED}usr/share/info" \
+				localstatedir="${ED}var/lib" \
+				mandir="${ED}usr/share/man" \
+				sysconfdir="${ED}etc" \
+				${LOCAL_EXTRA_EINSTALL} \
+				${MAKEOPTS} -j1 \
+				"$@" ${EXTRA_EMAKE} install
+		fi
+		if ! ${MAKE:-make} prefix="${ED}usr" \
+			datadir="${ED}usr/share" \
+			infodir="${ED}usr/share/info" \
+			localstatedir="${ED}var/lib" \
+			mandir="${ED}usr/share/man" \
+			sysconfdir="${ED}etc" \
+			${LOCAL_EXTRA_EINSTALL} \
+			${MAKEOPTS} -j1 \
+			"$@" ${EXTRA_EMAKE} install
+		then
+			__helpers_die "einstall failed"
+			return 1
+		fi
+	else
+		die "no Makefile found"
+	fi
+}
+
+__eapi0_pkg_nofetch() {
+	[ -z "${SRC_URI}" ] && return
+
+	elog "The following are listed in SRC_URI for ${PN}:"
+	local x
+	for x in $(echo ${SRC_URI}); do
+		elog "   ${x}"
+	done
+}
+
+__eapi0_src_unpack() {
+	[[ -n ${A} ]] && unpack ${A}
+}
+
+__eapi0_src_compile() {
+	if [ -x ./configure ] ; then
+		econf
+	fi
+	__eapi2_src_compile
+}
+
+__eapi0_src_test() {
+	# Since we don't want emake's automatic die
+	# support (EAPI 4 and later), and we also don't
+	# want the warning messages that it produces if
+	# we call it in 'nonfatal' mode, we use emake_cmd
+	# to emulate the desired parts of emake behavior.
+	local emake_cmd="${MAKE:-make} ${MAKEOPTS} ${EXTRA_EMAKE}"
+	local internal_opts=
+	if ___eapi_default_src_test_disables_parallel_jobs; then
+		internal_opts+=" -j1"
+	fi
+	if $emake_cmd ${internal_opts} check -n &> /dev/null; then
+		__vecho "${emake_cmd} ${internal_opts} check" >&2
+		$emake_cmd ${internal_opts} check || \
+			die "Make check failed. See above for details."
+	elif $emake_cmd ${internal_opts} test -n &> /dev/null; then
+		__vecho "${emake_cmd} ${internal_opts} test" >&2
+		$emake_cmd ${internal_opts} test || \
+			die "Make test failed. See above for details."
+	fi
+}
+
+__eapi1_src_compile() {
+	__eapi2_src_configure
+	__eapi2_src_compile
+}
+
+__eapi2_src_prepare() {
+	:
+}
+
+__eapi2_src_configure() {
+	if [[ -x ${ECONF_SOURCE:-.}/configure ]] ; then
+		econf
+	fi
+}
+
+__eapi2_src_compile() {
+	if [ -f Makefile ] || [ -f GNUmakefile ] || [ -f makefile ]; then
+		emake || die "emake failed"
+	fi
+}
+
+__eapi4_src_install() {
+	if [[ -f Makefile || -f GNUmakefile || -f makefile ]] ; then
+		emake DESTDIR="${D}" install
+	fi
+
+	if ! declare -p DOCS &>/dev/null ; then
+		local d
+		for d in README* ChangeLog AUTHORS NEWS TODO CHANGES \
+				THANKS BUGS FAQ CREDITS CHANGELOG ; do
+			[[ -s "${d}" ]] && dodoc "${d}"
+		done
+	elif [[ $(declare -p DOCS) == "declare -a "* ]] ; then
+		dodoc "${DOCS[@]}"
+	else
+		dodoc ${DOCS}
+	fi
+}
+
+__eapi6_src_prepare() {
+	if [[ $(declare -p PATCHES) == "declare -a"* ]]; then
+		eapply "${PATCHES[@]}"
+	elif [[ -n ${PATCHES} ]]; then
+		eapply ${PATCHES}
+	fi
+
+	eapply_user
+}
+
+__eapi6_src_install() {
+	if [[ -f Makefile || -f GNUmakefile || -f makefile ]] ; then
+		emake DESTDIR="${D}" install
+	fi
+
+	einstalldocs
+}
+
+# @FUNCTION: has_version
+# @USAGE: [--host-root] <DEPEND ATOM>
+# @DESCRIPTION:
+# Return true if given package is installed. Otherwise return false.
+# Callers may override the ROOT variable in order to match packages from an
+# alternative ROOT.
+has_version() {
+
+	local atom eroot host_root=false root=${ROOT}
+	if [[ $1 == --host-root ]] ; then
+		host_root=true
+		shift
+	fi
+	atom=$1
+	shift
+	[ $# -gt 0 ] && die "${FUNCNAME[0]}: unused argument(s): $*"
+
+	if ${host_root} ; then
+		if ! ___eapi_best_version_and_has_version_support_--host-root; then
+			die "${FUNCNAME[0]}: option --host-root is not supported with EAPI ${EAPI}"
+		fi
+		root=/
+	fi
+
+	if ___eapi_has_prefix_variables; then
+		# [[ ${root} == / ]] would be ambiguous here,
+		# since both prefixes can share root=/ while
+		# having different EPREFIX offsets.
+		if ${host_root} ; then
+			eroot=${root%/}${PORTAGE_OVERRIDE_EPREFIX}/
+		else
+			eroot=${root%/}${EPREFIX}/
+		fi
+	else
+		eroot=${root}
+	fi
+	if [[ -n $PORTAGE_IPC_DAEMON ]] ; then
+		"$PORTAGE_BIN_PATH"/ebuild-ipc has_version "${eroot}" "${atom}"
+	else
+		"${PORTAGE_BIN_PATH}/ebuild-helpers/portageq" has_version "${eroot}" "${atom}"
+	fi
+	local retval=$?
+	case "${retval}" in
+		0|1)
+			return ${retval}
+			;;
+		2)
+			die "${FUNCNAME[0]}: invalid atom: ${atom}"
+			;;
+		*)
+			if [[ -n ${PORTAGE_IPC_DAEMON} ]]; then
+				die "${FUNCNAME[0]}: unexpected ebuild-ipc exit code: ${retval}"
+			else
+				die "${FUNCNAME[0]}: unexpected portageq exit code: ${retval}"
+			fi
+			;;
+	esac
+}
+
+# @FUNCTION: best_version
+# @USAGE: [--host-root] <DEPEND ATOM>
+# @DESCRIPTION:
+# Returns highest installed matching category/package-version (without .ebuild).
+# Callers may override the ROOT variable in order to match packages from an
+# alternative ROOT.
+best_version() {
+
+	local atom eroot host_root=false root=${ROOT}
+	if [[ $1 == --host-root ]] ; then
+		host_root=true
+		shift
+	fi
+	atom=$1
+	shift
+	[ $# -gt 0 ] && die "${FUNCNAME[0]}: unused argument(s): $*"
+
+	if ${host_root} ; then
+		if ! ___eapi_best_version_and_has_version_support_--host-root; then
+			die "${FUNCNAME[0]}: option --host-root is not supported with EAPI ${EAPI}"
+		fi
+		root=/
+	fi
+
+	if ___eapi_has_prefix_variables; then
+		# [[ ${root} == / ]] would be ambiguous here,
+		# since both prefixes can share root=/ while
+		# having different EPREFIX offsets.
+		if ${host_root} ; then
+			eroot=${root%/}${PORTAGE_OVERRIDE_EPREFIX}/
+		else
+			eroot=${root%/}${EPREFIX}/
+		fi
+	else
+		eroot=${root}
+	fi
+	if [[ -n $PORTAGE_IPC_DAEMON ]] ; then
+		"$PORTAGE_BIN_PATH"/ebuild-ipc best_version "${eroot}" "${atom}"
+	else
+		"${PORTAGE_BIN_PATH}/ebuild-helpers/portageq" best_version "${eroot}" "${atom}"
+	fi
+	local retval=$?
+	case "${retval}" in
+		0|1)
+			return ${retval}
+			;;
+		2)
+			die "${FUNCNAME[0]}: invalid atom: ${atom}"
+			;;
+		*)
+			if [[ -n ${PORTAGE_IPC_DAEMON} ]]; then
+				die "${FUNCNAME[0]}: unexpected ebuild-ipc exit code: ${retval}"
+			else
+				die "${FUNCNAME[0]}: unexpected portageq exit code: ${retval}"
+			fi
+			;;
+	esac
+}
+
+if ___eapi_has_get_libdir; then
+	get_libdir() {
+		local libdir_var="LIBDIR_${ABI}"
+		local libdir="lib"
+
+		[[ -n ${ABI} && -n ${!libdir_var} ]] && libdir=${!libdir_var}
+
+		echo "${libdir}"
+	}
+fi
+
+if ___eapi_has_einstalldocs; then
+	einstalldocs() {
+		(
+			docinto .
+			if ! declare -p DOCS &>/dev/null ; then
+				local d
+				for d in README* ChangeLog AUTHORS NEWS TODO CHANGES \
+						THANKS BUGS FAQ CREDITS CHANGELOG ; do
+					[[ -s ${d} ]] && dodoc "${d}"
+				done
+			elif [[ $(declare -p DOCS) == "declare -a"* ]] ; then
+				[[ ${DOCS[@]} ]] && dodoc -r "${DOCS[@]}"
+			else
+				[[ ${DOCS} ]] && dodoc -r ${DOCS}
+			fi
+		)
+
+		(
+			docinto html
+			if [[ $(declare -p HTML_DOCS 2>/dev/null) == "declare -a"* ]] ; then
+				[[ ${HTML_DOCS[@]} ]] && dodoc -r "${HTML_DOCS[@]}"
+			else
+				[[ ${HTML_DOCS} ]] && dodoc -r ${HTML_DOCS}
+			fi
+		)
+	}
+fi
+
+if ___eapi_has_eapply; then
+	eapply() {
+		_eapply_patch() {
+			local f=${1}
+			local prefix=${2}
+
+			started_applying=1
+			ebegin "${prefix:-Applying }${f##*/}"
+			# -p1 as a sane default
+			# -f to avoid interactivity
+			# -s to silence progress output
+			patch -p1 -f -s "${patch_options[@]}" < "${f}"
+			if ! eend ${?}; then
+				__helpers_die "patch -p1 ${patch_options[*]} failed with ${f}"
+				failed=1
+			fi
+		}
+
+		local f patch_options=() failed started_applying options_terminated
+		for f; do
+			if [[ ${f} == -* && -z ${options_terminated} ]]; then
+				if [[ -n ${started_applying} ]]; then
+					die "eapply: options need to be specified before files"
+				fi
+				if [[ ${f} == -- ]]; then
+					options_terminated=1
+				else
+					patch_options+=( ${f} )
+				fi
+			elif [[ -d ${f} ]]; then
+				_eapply_get_files() {
+					local LC_ALL=POSIX
+					local prev_shopt=$(shopt -p nullglob)
+					shopt -s nullglob
+					files=( "${f}"/*.{patch,diff} )
+					${prev_shopt}
+				}
+
+				local files
+				_eapply_get_files
+				[[ -z ${files[@]} ]] && die "No *.{patch,diff} files in directory ${f}"
+
+				einfo "Applying patches from ${f} ..."
+				local f2
+				for f2 in "${files[@]}"; do
+					_eapply_patch "${f2}" '  '
+
+					# in case of nonfatal
+					[[ -n ${failed} ]] && return 1
+				done
+			else
+				_eapply_patch "${f}"
+
+				# in case of nonfatal
+				[[ -n ${failed} ]] && return 1
+			fi
+		done
+
+		return 0
+	}
+fi
+
+if ___eapi_has_eapply_user; then
+	eapply_user() {
+		local basedir=${PORTAGE_CONFIGROOT%/}/etc/portage/patches
+
+		local d applied
+		# possibilities:
+		# 1. ${CATEGORY}/${P}-${PR} (note: -r0 desired to avoid applying
+		#    ${P} twice)
+		# 2. ${CATEGORY}/${P}
+		# 3. ${CATEGORY}/${PN}
+		# all of the above may be optionally followed by a slot
+		for d in "${basedir}"/${CATEGORY}/{${P}-${PR},${P},${PN}}{,:${SLOT%/*}}; do
+			if [[ -d ${d} ]]; then
+				eapply "${d}"
+				applied=1
+			fi
+		done
+
+		[[ -n ${applied} ]] && ewarn "User patches applied."
+	}
+fi
+
+if ___eapi_has_in_iuse; then
+	in_iuse() {
+		local use=${1}
+
+		if [[ -z "${use}" ]]; then
+			echo "!!! in_iuse() called without a parameter." >&2
+			echo "!!! in_iuse <USEFLAG>" >&2
+			die "in_iuse() called without a parameter"
+		fi
+
+		local liuse=( ${IUSE_EFFECTIVE} )
+
+		has "${use}" "${liuse[@]#[+-]}"
+	}
+fi
+
+if ___eapi_has_master_repositories; then
+	master_repositories() {
+		local output repository=$1 retval
+		shift
+		[[ $# -gt 0 ]] && die "${FUNCNAME[0]}: unused argument(s): $*"
+
+		if [[ -n ${PORTAGE_IPC_DAEMON} ]]; then
+			"${PORTAGE_BIN_PATH}/ebuild-ipc" master_repositories "${EROOT}" "${repository}"
+		else
+			output=$("${PORTAGE_BIN_PATH}/ebuild-helpers/portageq" master_repositories "${EROOT}" "${repository}")
+		fi
+		retval=$?
+		[[ -n ${output} ]] && echo "${output}"
+		case "${retval}" in
+			0|1)
+				return ${retval}
+				;;
+			2)
+				die "${FUNCNAME[0]}: invalid repository: ${repository}"
+				;;
+			*)
+				if [[ -n ${PORTAGE_IPC_DAEMON} ]]; then
+					die "${FUNCNAME[0]}: unexpected ebuild-ipc exit code: ${retval}"
+				else
+					die "${FUNCNAME[0]}: unexpected portageq exit code: ${retval}"
+				fi
+				;;
+		esac
+	}
+fi
+
+if ___eapi_has_repository_path; then
+	repository_path() {
+		local output repository=$1 retval
+		shift
+		[[ $# -gt 0 ]] && die "${FUNCNAME[0]}: unused argument(s): $*"
+
+		if [[ -n ${PORTAGE_IPC_DAEMON} ]]; then
+			"${PORTAGE_BIN_PATH}/ebuild-ipc" repository_path "${EROOT}" "${repository}"
+		else
+			output=$("${PORTAGE_BIN_PATH}/ebuild-helpers/portageq" get_repo_path "${EROOT}" "${repository}")
+		fi
+		retval=$?
+		[[ -n ${output} ]] && echo "${output}"
+		case "${retval}" in
+			0|1)
+				return ${retval}
+				;;
+			2)
+				die "${FUNCNAME[0]}: invalid repository: ${repository}"
+				;;
+			*)
+				if [[ -n ${PORTAGE_IPC_DAEMON} ]]; then
+					die "${FUNCNAME[0]}: unexpected ebuild-ipc exit code: ${retval}"
+				else
+					die "${FUNCNAME[0]}: unexpected portageq exit code: ${retval}"
+				fi
+				;;
+		esac
+	}
+fi
+
+if ___eapi_has_available_eclasses; then
+	available_eclasses() {
+		local output repository=${PORTAGE_REPO_NAME} retval
+		[[ $# -gt 0 ]] && die "${FUNCNAME[0]}: unused argument(s): $*"
+
+		if [[ -n ${PORTAGE_IPC_DAEMON} ]]; then
+			"${PORTAGE_BIN_PATH}/ebuild-ipc" available_eclasses "${EROOT}" "${repository}"
+		else
+			output=$("${PORTAGE_BIN_PATH}/ebuild-helpers/portageq" available_eclasses "${EROOT}" "${repository}")
+		fi
+		retval=$?
+		[[ -n ${output} ]] && echo "${output}"
+		case "${retval}" in
+			0|1)
+				return ${retval}
+				;;
+			2)
+				die "${FUNCNAME[0]}: invalid repository: ${repository}"
+				;;
+			*)
+				if [[ -n ${PORTAGE_IPC_DAEMON} ]]; then
+					die "${FUNCNAME[0]}: unexpected ebuild-ipc exit code: ${retval}"
+				else
+					die "${FUNCNAME[0]}: unexpected portageq exit code: ${retval}"
+				fi
+				;;
+		esac
+	}
+fi
+
+if ___eapi_has_eclass_path; then
+	eclass_path() {
+		local eclass=$1 output repository=${PORTAGE_REPO_NAME} retval
+		shift
+		[[ $# -gt 0 ]] && die "${FUNCNAME[0]}: unused argument(s): $*"
+
+		if [[ -n ${PORTAGE_IPC_DAEMON} ]]; then
+			"${PORTAGE_BIN_PATH}/ebuild-ipc" eclass_path "${EROOT}" "${repository}" "${eclass}"
+		else
+			output=$("${PORTAGE_BIN_PATH}/ebuild-helpers/portageq" eclass_path "${EROOT}" "${repository}" "${eclass}")
+		fi
+		retval=$?
+		[[ -n ${output} ]] && echo "${output}"
+		case "${retval}" in
+			0|1)
+				return ${retval}
+				;;
+			2)
+				die "${FUNCNAME[0]}: invalid repository: ${repository}"
+				;;
+			*)
+				if [[ -n ${PORTAGE_IPC_DAEMON} ]]; then
+					die "${FUNCNAME[0]}: unexpected ebuild-ipc exit code: ${retval}"
+				else
+					die "${FUNCNAME[0]}: unexpected portageq exit code: ${retval}"
+				fi
+				;;
+		esac
+	}
+fi
+
+if ___eapi_has_license_path; then
+	license_path() {
+		local license=$1 output repository=${PORTAGE_REPO_NAME} retval
+		shift
+		[[ $# -gt 0 ]] && die "${FUNCNAME[0]}: unused argument(s): $*"
+
+		if [[ -n ${PORTAGE_IPC_DAEMON} ]]; then
+			"${PORTAGE_BIN_PATH}/ebuild-ipc" license_path "${EROOT}" "${repository}" "${license}"
+		else
+			output=$("${PORTAGE_BIN_PATH}/ebuild-helpers/portageq" license_path "${EROOT}" "${repository}" "${license}")
+		fi
+		retval=$?
+		[[ -n ${output} ]] && echo "${output}"
+		case "${retval}" in
+			0|1)
+				return ${retval}
+				;;
+			2)
+				die "${FUNCNAME[0]}: invalid repository: ${repository}"
+				;;
+			*)
+				if [[ -n ${PORTAGE_IPC_DAEMON} ]]; then
+					die "${FUNCNAME[0]}: unexpected ebuild-ipc exit code: ${retval}"
+				else
+					die "${FUNCNAME[0]}: unexpected portageq exit code: ${retval}"
+				fi
+				;;
+		esac
+	}
+fi
+
+if ___eapi_has_package_manager_build_user; then
+	package_manager_build_user() {
+		echo "${PORTAGE_BUILD_USER}"
+	}
+fi
+
+if ___eapi_has_package_manager_build_group; then
+	package_manager_build_group() {
+		echo "${PORTAGE_BUILD_GROUP}"
+	}
+fi

--- a/share/save-ebuild-env.sh
+++ b/share/save-ebuild-env.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+# @FUNCTION: __save_ebuild_env
+# @DESCRIPTION:
+# echo the current environment to stdout, filtering out redundant info.
+#
+# --exclude-init-phases causes pkg_nofetch and src_* phase functions to
+# be excluded from the output. These function are not needed for installation
+# or removal of the packages, and can therefore be safely excluded.
+#
+__save_ebuild_env() {
+	(
+	if has --exclude-init-phases $* ; then
+		unset S _E_DOCDESTTREE_ _E_EXEDESTTREE_ \
+			PORTAGE_DOCOMPRESS_SIZE_LIMIT PORTAGE_DOCOMPRESS \
+			PORTAGE_DOCOMPRESS_SKIP
+		if [[ -n $PYTHONPATH &&
+			${PYTHONPATH%%:*} -ef $PORTAGE_PYM_PATH ]] ; then
+			if [[ $PYTHONPATH == *:* ]] ; then
+				export PYTHONPATH=${PYTHONPATH#*:}
+			else
+				unset PYTHONPATH
+			fi
+		fi
+	fi
+
+	# misc variables inherited from the calling environment
+	unset COLORTERM DISPLAY EDITOR LESS LESSOPEN LOGNAME LS_COLORS PAGER \
+		TERM TERMCAP USER ftp_proxy http_proxy no_proxy
+
+	# other variables inherited from the calling environment
+	unset CVS_RSH ECHANGELOG_USER GPG_AGENT_INFO \
+	SSH_AGENT_PID SSH_AUTH_SOCK STY WINDOW XAUTHORITY
+
+	# CCACHE and DISTCC config
+	unset ${!CCACHE_*} ${!DISTCC_*}
+
+	# There's no need to bloat environment.bz2 with internally defined
+	# functions and variables, so filter them out if possible.
+
+	for x in pkg_setup pkg_nofetch src_unpack src_prepare src_configure \
+		src_compile src_test src_install pkg_preinst pkg_postinst \
+		pkg_prerm pkg_postrm pkg_config pkg_info pkg_pretend ; do
+		unset -f default_$x __eapi{0,1,2,3,4}_$x
+	done
+	unset x
+
+	unset -f assert __assert_sigpipe_ok \
+		__dump_trace die \
+		__quiet_mode __vecho __elog_base eqawarn elog \
+		einfo einfon ewarn eerror ebegin __eend eend KV_major \
+		KV_minor KV_micro KV_to_int get_KV __1 __1 has \
+		__has_phase_defined_up_to \
+		hasv hasq __qa_source __qa_call \
+		addread addwrite adddeny addpredict __sb_append_var \
+		use usev useq has_version portageq \
+		best_version use_with use_enable register_die_hook \
+		unpack __strip_duplicate_slashes econf einstall \
+		__dyn_setup __dyn_unpack __dyn_clean \
+		into insinto exeinto docinto \
+		insopts diropts exeopts libopts docompress \
+		__abort_handler __abort_prepare __abort_configure __abort_compile \
+		__abort_test __abort_install __dyn_prepare __dyn_configure \
+		__dyn_compile __dyn_test __dyn_install \
+		__dyn_pretend __dyn_help \
+		debug-print debug-print-function \
+		debug-print-section __helpers_die inherit EXPORT_FUNCTIONS \
+		nonfatal register_success_hook \
+		__hasg __hasgq \
+		__save_ebuild_env __set_colors __filter_readonly_variables \
+		__preprocess_ebuild_env \
+		__repo_attr __source_all_bashrcs \
+		__ebuild_main __ebuild_phase __ebuild_phase_with_hooks \
+		__ebuild_arg_to_phase __ebuild_phase_funcs default \
+		__unpack_tar __unset_colors \
+		__source_env_files __try_source \
+		__eqaquote __eqatag \
+		${QA_INTERCEPTORS}
+
+	___eapi_has_usex && unset -f usex
+	___eapi_has_master_repositories && unset -f master_repositories
+	___eapi_has_repository_path && unset -f repository_path
+	___eapi_has_available_eclasses && unset -f available_eclasses
+	___eapi_has_eclass_path && unset -f eclass_path
+	___eapi_has_license_path && unset -f license_path
+	___eapi_has_package_manager_build_user && unset -f package_manager_build_user
+	___eapi_has_package_manager_build_group && unset -f package_manager_build_group
+
+	unset -f $(compgen -A function ___eapi_)
+
+	# portage config variables and variables set directly by portage
+	unset ACCEPT_LICENSE BAD BRACKET BUILD_PREFIX COLS \
+		DISTCC_DIR DISTCC_SOCKS5_PROXY DISTDIR DOC_SYMLINKS_DIR \
+		EBUILD_FORCE_TEST EBUILD_MASTER_PID \
+		ECLASS_DEPTH ENDCOL FAKEROOTKEY \
+		GOOD HILITE HOME \
+		LAST_E_CMD LAST_E_LEN LD_PRELOAD MISC_FUNCTIONS_ARGS MOPREFIX \
+		NOCOLOR NORMAL PKGDIR PKGUSE PKG_LOGDIR PKG_TMPDIR \
+		PORTAGE_BASHRC_FILES PORTAGE_BASHRCS_SOURCED PORTAGE_COMPRESS \
+		PORTAGE_COMPRESS_EXCLUDE_SUFFIXES \
+		PORTAGE_DOHTML_UNWARNED_SKIPPED_EXTENSIONS \
+		PORTAGE_DOHTML_UNWARNED_SKIPPED_FILES \
+		PORTAGE_DOHTML_WARN_ON_SKIPPED_FILES \
+		PORTAGE_NONFATAL PORTAGE_QUIET \
+		PORTAGE_SANDBOX_DENY PORTAGE_SANDBOX_PREDICT \
+		PORTAGE_SANDBOX_READ PORTAGE_SANDBOX_WRITE \
+		PORTAGE_SOCKS5_PROXY PREROOTPATH \
+		QA_INTERCEPTORS \
+		RC_DEFAULT_INDENT RC_DOT_PATTERN RC_ENDCOL RC_INDENTATION  \
+		ROOT ROOTPATH RPMDIR TEMP TMP TMPDIR USE_EXPAND \
+		WARN XARGS _RC_GET_KV_CACHE
+
+	# user config variables
+	unset DOC_SYMLINKS_DIR INSTALL_MASK PKG_INSTALL_MASK
+
+	declare -p
+	declare -fp
+	if [[ ${BASH_VERSINFO[0]} == 3 ]]; then
+		export
+	fi
+	)
+}

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,0 +1,80 @@
+
+use strict;
+use warnings;
+
+use Test::More;
+use Path::Tiny qw( path );
+use Test::File::ShareDir::Module {
+    'Gentoo::Ebuild::ParseVariables' => 'share/';
+};
+use Gentoo::Ebuild::ParseVariables qw( gentoo_ebuild_var );
+use Test::TempDir::Tiny qw( tempdir );
+
+# ABSTRACT: Test sourcing
+
+in_tempdir(
+    "fake-overlay" => sub {
+        path('eclass')->mkpath;
+        path('dev-perl/example')->mkpath;
+        path('profiles')->mkpath;
+        path('metadata')->mkpath;
+        path('profiles/repo_name')->spew_raw('fake-overlay');
+        path('layout.conf')->spew_raw(<<'EOF');
+masters = gentoo
+EOF
+        path('eclass/perl-module.eclass')->spew_raw(<<'EOF');
+RDEPEND="dev-lang/perl:="
+EOF
+        path('dev-perl/example/example-1.1.0.ebuild')->spew_raw(<<'EOF');
+EAPI=5
+
+inherit perl-module
+RDEPEND="virtual/perl-ExtUtils-MakeMaker"
+DEPEND="${RDEPEND}"
+
+EOF
+        my $hash =
+          gentoo_ebuild_var(
+            path('dev-perl/example/example-1.1.0.ebuild')->absolute,
+          );
+        note explain $hash;
+        ok( exists $hash->{RDEPEND}, 'RDEPEND exists' );
+        like(
+            $hash->{DEPEND},
+            qr/virtual\/perl-ExtUtils-MakeMaker/,
+            'RDEPEND interpolated'
+        );
+        like( $hash->{RDEPEND}, qr/dev-lang\/perl/,
+            'RDEPEND in eclass propagated' );
+    }
+);
+
+done_testing;
+
+use Cwd qw/abs_path/;
+
+sub in_tempdir {
+    my ( $label, $code ) = @_;
+    my $wantarray = wantarray;
+    my $cwd       = abs_path(".");
+    my $tempdir   = tempdir($label);
+
+    chdir $tempdir or die "Can't chdir to '$tempdir'";
+    my (@ret);
+    my $ok = eval {
+        if ($wantarray) {
+            @ret = $code->($tempdir);
+        }
+        elsif ( defined $wantarray ) {
+            $ret[0] = $code->($tempdir);
+        }
+        else {
+            $code->($tempdir);
+        }
+        1;
+    };
+    my $err = $@;
+    chdir $cwd or chdir "/" or die "Can't chdir to either '$cwd' or '/'";
+    die $err if !$ok;
+    return $wantarray ? @ret : $ret[0];
+}


### PR DESCRIPTION
This is more a code review request for sanity because I don't know what I'm doing here, I'm just poking the bits till I get a useful output.
1. eclass.sh was grossly outdated.
2. modern ones have this silly `PORTAGE_BIN_PATH="${PORTAGE_BIN_PATH:-/usr/lib/portage/bin}"` shit, which is useless, because ...

```
/usr/lib/portage/python2.7/ebuild.sh
/usr/lib/portage/python3.4/ebuild.sh
```

So there's no way to know where that is from perl land. So I just stuffed them in the sharedir and forced the bin path to the share dir and crossed my fingers.
1. There's a lot of garbage variables that have to be turned on to make the magic smoke come out.  I probably did something wrong, but tests demonstrate I can do very rudimentary shit with it now.

I would _love_ to avoid Shell::EnvImporter as it is grossly unmaintained. But ETOOHARD.
